### PR TITLE
feat: add shareable per-league URLs for Results/Schedule/Standings

### DIFF
--- a/app/results/ResultsClient.js
+++ b/app/results/ResultsClient.js
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import { Trophy, ChevronUp, ChevronDown, ChevronDown as ChevronIcon, Clock } from 'lucide-react'
 import LeagueSelector from '@/components/ui/LeagueSelector'
 import { cn, formatDate, getSlotInfo, getTeamAbbreviation } from '@/lib/utils'
@@ -291,11 +292,18 @@ function SlotGroup({ slot, tiers }) {
 /* ═══════════════════════════════════════════════
    MAIN RESULTS CLIENT
    ═══════════════════════════════════════════════ */
-export default function ResultsClient({ leagues }) {
-  const [selected, setSelected] = useState(leagues[0]?.slug || '')
+export default function ResultsClient({ leagues, initialSlug }) {
+  const router = useRouter()
+  const [selected, setSelected] = useState(initialSlug || leagues[0]?.slug || '')
   const [data, setData] = useState(null)
   const [loading, setLoading] = useState(true)
   const [selectedWeek, setSelectedWeek] = useState(null)
+
+  // Keep the URL in sync with the selected league for shareable deep links
+  const handleSelect = (slug) => {
+    setSelected(slug)
+    router.replace(`/results/${slug}`, { scroll: false })
+  }
 
   useEffect(() => {
     if (!selected) return
@@ -336,7 +344,7 @@ export default function ResultsClient({ leagues }) {
         </div>
 
         <div className="mb-6">
-          <LeagueSelector leagues={leagues} selected={selected} onSelect={setSelected} />
+          <LeagueSelector leagues={leagues} selected={selected} onSelect={handleSelect} />
         </div>
 
         {loading ? (

--- a/app/results/[slug]/page.js
+++ b/app/results/[slug]/page.js
@@ -1,0 +1,38 @@
+import prisma from '@/lib/prisma'
+import { notFound } from 'next/navigation'
+import ResultsClient from '../ResultsClient'
+
+export const dynamic = 'force-dynamic'
+
+export async function generateMetadata({ params }) {
+  const { slug } = await params
+  const league = await prisma.league.findUnique({
+    where: { slug },
+    select: { name: true },
+  })
+  if (!league) return { title: 'Results' }
+  return {
+    title: `${league.name} Results`,
+    description: `Weekly match results and tier standings for ${league.name} at Tito's Courts.`,
+  }
+}
+
+async function getData() {
+  const leagues = await prisma.league.findMany({
+    where: { isActive: true },
+    select: { slug: true, name: true, dayOfWeek: true },
+    orderBy: { createdAt: 'asc' },
+  })
+  return { leagues }
+}
+
+export default async function ResultsLeaguePage({ params }) {
+  const { slug } = await params
+  const { leagues } = await getData()
+
+  // Validate slug belongs to an active league
+  const valid = leagues.some(l => l.slug === slug)
+  if (!valid) notFound()
+
+  return <ResultsClient leagues={leagues} initialSlug={slug} />
+}

--- a/app/schedule/ScheduleClient.js
+++ b/app/schedule/ScheduleClient.js
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import { Clock, ChevronDown, Shield } from 'lucide-react'
 import LeagueSelector from '@/components/ui/LeagueSelector'
 import TeamFilter from '@/components/ui/TeamFilter'
@@ -289,10 +290,17 @@ function SlotGroup({ slot, tiers, myTeam, isMens }) {
 /* ═══════════════════════════════════════════════
    MAIN SCHEDULE CLIENT
    ═══════════════════════════════════════════════ */
-export default function ScheduleClient({ leagues }) {
-  const [selected, setSelected] = useState(leagues[0]?.slug || '')
+export default function ScheduleClient({ leagues, initialSlug }) {
+  const router = useRouter()
+  const [selected, setSelected] = useState(initialSlug || leagues[0]?.slug || '')
   const [schedule, setSchedule] = useState(null)
   const [loading, setLoading] = useState(true)
+
+  // Sync URL with selected league for shareable deep links
+  const handleSelect = (slug) => {
+    setSelected(slug)
+    router.replace(`/schedule/${slug}`, { scroll: false })
+  }
   const [myTeam, setMyTeam] = useMyTeam(selected)
 
   const isMens = selected.includes('sunday') || selected.includes('mens')
@@ -338,7 +346,7 @@ export default function ScheduleClient({ leagues }) {
         </div>
 
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 mb-8">
-          <LeagueSelector leagues={leagues} selected={selected} onSelect={setSelected} />
+          <LeagueSelector leagues={leagues} selected={selected} onSelect={handleSelect} />
           {[...allTeams].length > 0 && (
             <TeamFilter teams={[...allTeams].sort()} selected={myTeam} onSelect={setMyTeam} />
           )}

--- a/app/schedule/[slug]/page.js
+++ b/app/schedule/[slug]/page.js
@@ -1,0 +1,42 @@
+import prisma from '@/lib/prisma'
+import { notFound } from 'next/navigation'
+import ScheduleClient from '../ScheduleClient'
+
+export const dynamic = 'force-dynamic'
+
+export async function generateMetadata({ params }) {
+  const { slug } = await params
+  const league = await prisma.league.findUnique({
+    where: { slug },
+    select: { name: true },
+  })
+  if (!league) return { title: 'Schedule' }
+  return {
+    title: `${league.name} Schedule`,
+    description: `Weekly game schedule for ${league.name} at Tito's Courts. Find your tier, court, and opponents.`,
+  }
+}
+
+async function getData() {
+  try {
+    const leagues = await prisma.league.findMany({
+      where: { isActive: true },
+      select: { slug: true, name: true, dayOfWeek: true },
+      orderBy: { createdAt: 'asc' },
+    })
+    return { leagues }
+  } catch (error) {
+    console.error('Schedule slug page data error:', error.message)
+    return { leagues: [] }
+  }
+}
+
+export default async function ScheduleLeaguePage({ params }) {
+  const { slug } = await params
+  const { leagues } = await getData()
+
+  const valid = leagues.some(l => l.slug === slug)
+  if (!valid) notFound()
+
+  return <ScheduleClient leagues={leagues} initialSlug={slug} />
+}

--- a/app/standings/StandingsClient.js
+++ b/app/standings/StandingsClient.js
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import { Trophy } from 'lucide-react'
 import SectionHeading from '@/components/ui/SectionHeading'
 import LeagueSelector from '@/components/ui/LeagueSelector'
@@ -226,13 +227,20 @@ function SlotDivider({ label, color }) {
 
 /* ─── Main Component ─── */
 
-export default function StandingsClient({ leagues }) {
-  const [selected, setSelected] = useState(leagues[0]?.slug || '')
+export default function StandingsClient({ leagues, initialSlug }) {
+  const router = useRouter()
+  const [selected, setSelected] = useState(initialSlug || leagues[0]?.slug || '')
   const [standings, setStandings] = useState(null)
   const [tierView, setTierView] = useState(null)
   const [view, setView] = useState('overall')
   const [loading, setLoading] = useState(true)
   const [myTeam, setMyTeam] = useMyTeam(selected)
+
+  // Sync URL with selected league for shareable deep links
+  const handleSelect = (slug) => {
+    setSelected(slug)
+    router.replace(`/standings/${slug}`, { scroll: false })
+  }
 
   useEffect(() => {
     if (!selected) return
@@ -251,7 +259,7 @@ export default function StandingsClient({ leagues }) {
         <SectionHeading label="RANKINGS" title="Season Standings" description="Overall league standings and current tier placements." />
 
         <div className="mt-8 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-4">
-          <LeagueSelector leagues={leagues} selected={selected} onSelect={setSelected} />
+          <LeagueSelector leagues={leagues} selected={selected} onSelect={handleSelect} />
 
           <div className="flex gap-2">
             {['overall', 'tiers'].map(v => (

--- a/app/standings/[slug]/page.js
+++ b/app/standings/[slug]/page.js
@@ -1,0 +1,37 @@
+import prisma from '@/lib/prisma'
+import { notFound } from 'next/navigation'
+import StandingsClient from '../StandingsClient'
+
+export const dynamic = 'force-dynamic'
+
+export async function generateMetadata({ params }) {
+  const { slug } = await params
+  const league = await prisma.league.findUnique({
+    where: { slug },
+    select: { name: true },
+  })
+  if (!league) return { title: 'Standings' }
+  return {
+    title: `${league.name} Standings`,
+    description: `Current season standings for ${league.name} at Tito's Courts. Track rankings, wins, losses, and playoff divisions.`,
+  }
+}
+
+async function getData() {
+  const leagues = await prisma.league.findMany({
+    where: { isActive: true },
+    select: { slug: true, name: true, dayOfWeek: true },
+    orderBy: { createdAt: 'asc' },
+  })
+  return { leagues }
+}
+
+export default async function StandingsLeaguePage({ params }) {
+  const { slug } = await params
+  const { leagues } = await getData()
+
+  const valid = leagues.some(l => l.slug === slug)
+  if (!valid) notFound()
+
+  return <StandingsClient leagues={leagues} initialSlug={slug} />
+}


### PR DESCRIPTION
Why: Previously, links like /schedule always opened on Tuesday COED. Sharing a link for the Men's Schedule required the recipient to click a tab to get to the right view — not shareable or bookmarkable.

What changed
- Added dynamic slug routes for all three multi-league pages:
  - /results/[slug]   (e.g., /results/sunday-mens)
  - /schedule/[slug]  (e.g., /schedule/sunday-mens)
  - /standings/[slug] (e.g., /standings/sunday-mens)
- Each slug page validates against active leagues (returns 404 for invalid slugs)
- Per-league metadata (title, description) for better link previews when shared
- Client components now accept initialSlug prop, and sync the URL to the
  selected league via router.replace when users click between tabs (no history
  spam, supports back button)
- Existing /results, /schedule, /standings routes still work and default to
  the first league