### PR TITLE
fix(prisma): cache adapter + cap pool size to prevent connection exha…

### DIFF
--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -3,13 +3,25 @@ import { PrismaPg } from "@prisma/adapter-pg";
 
 const globalForPrisma = globalThis;
 
-// Fix SSL warning: replace sslmode=require with sslmode=verify-full
-let connectionString = process.env.DATABASE_URL || '';
-connectionString = connectionString.replace('sslmode=require', 'sslmode=verify-full');
+function createClient() {
+  // Fix SSL warning: replace sslmode=require with sslmode=verify-full
+  let connectionString = process.env.DATABASE_URL || '';
+  connectionString = connectionString.replace('sslmode=require', 'sslmode=verify-full');
 
-const adapter = new PrismaPg({ connectionString });
+  // Cap pool size to stay under Prisma Postgres' per-role connection limit.
+  // Default (cpus * 2 + 1) is too high for hosted dev databases with low caps.
+  const adapter = new PrismaPg({
+    connectionString,
+    max: 3,
+    idleTimeoutMillis: 10_000,
+  });
+  return new PrismaClient({ adapter });
+}
 
-const prisma = globalForPrisma.prisma ?? new PrismaClient({ adapter });
+// Reuse a single Prisma client + adapter across hot reloads in development.
+// Creating a new adapter on every reload leaks connection pools until the
+// database role's connection limit is exhausted.
+const prisma = globalForPrisma.prisma ?? createClient();
 
 if (process.env.NODE_ENV !== "production") {
   globalForPrisma.prisma = prisma;


### PR DESCRIPTION
…ustion

Why: Running the dev server for a while would hit "too many connections for role prisma_migration" errors. Hot reloads were leaking connection pools — only the PrismaClient was cached on globalForPrisma, but the PrismaPg adapter (which owns the pool) was recreated on every module reload.

What changed
- Wrapped adapter + client creation in createClient() so both are cached together on globalForPrisma.prisma (hot reloads now reuse the same pool)
- Added explicit max: 3 on the adapter (was defaulting to cpus*2+1, too high for Prisma Postgres' low dev-tier connection limit)
- Added idleTimeoutMillis: 10_000 so idle connections release sooner