### PR TITLE
fix(logo): declare correct aspect ratio so Next/Image serves sharp va…

### DIFF
--- a/components/layout/Footer.js
+++ b/components/layout/Footer.js
@@ -67,8 +67,10 @@ export default function Footer() {
               <Image
                 src="/images/titos.png"
                 alt="Tito's Courts"
-                width={160}
-                height={40}
+                width={220}
+                height={128}
+                quality={95}
+                sizes="220px"
                 className="h-10 w-auto"
               />
             </Link>

--- a/components/layout/Navbar.js
+++ b/components/layout/Navbar.js
@@ -96,8 +96,10 @@ export default function Navbar() {
               <Image
                 src="/images/titosvl.png"
                 alt="Tito's Courts"
-                width={44}
-                height={44}
+                width={240}
+                height={127}
+                quality={95}
+                sizes="240px"
                 className="h-11 w-auto transition-transform duration-300 group-hover:scale-105"
                 priority
               />


### PR DESCRIPTION
The navbar and footer logos appeared blurry/pixelated on retina displays. Root cause: width/height props declared a 1:1 (navbar) and 4:1 (footer) ratio, but the actual source PNGs are 2559x1354 and 2288x1329 (~1.89:1 and ~1.72:1).

Next.js picks srcset variants based on the declared width, so it was serving 48px-wide source images that got upscaled to ~83-166 physical px on retina.

Fixed by:
- Setting width/height to match the real aspect ratio
- Bumping declared width to 240/220 so Next serves a 256w variant
- Adding quality={95} and sizes hint for proper variant selection