### PR TITLE
feat(mobile): inline tier expansion + remove match numbers

### DIFF
--- a/app/results/ResultsClient.js
+++ b/app/results/ResultsClient.js
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, Fragment } from 'react'
 import { useRouter } from 'next/navigation'
 import { Trophy, ChevronUp, ChevronDown, ChevronDown as ChevronIcon, Clock } from 'lucide-react'
 import LeagueSelector from '@/components/ui/LeagueSelector'
@@ -215,7 +215,6 @@ function ResultPanel({ tier, slotColorVar }) {
 
                 return (
                   <div key={i} className={cn('flex items-center gap-3 px-3 sm:px-4 py-2.5 rounded-xl bg-titos-elevated/40')}>
-                    <span className="text-titos-gray-500 text-xs font-bold w-5 flex-shrink-0">{i + 1}.</span>
                     <span className={cn('flex-1 text-right text-sm font-semibold truncate', homeWon ? 'text-titos-gold' : 'text-titos-white')}>
                       {m.homeTeam}
                     </span>
@@ -269,20 +268,31 @@ function SlotGroup({ slot, tiers }) {
       {/* Grid + expanded panel */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2.5 sm:gap-3">
         {sorted.map(tier => (
-          <TierCard
-            key={tier.tierNumber}
-            tier={tier}
-            slotColorVar={slotColorVar}
-            isSelected={expandedTier === tier.tierNumber}
-            onClick={() => setExpandedTier(expandedTier === tier.tierNumber ? null : tier.tierNumber)}
-          />
+          <Fragment key={tier.tierNumber}>
+            <TierCard
+              tier={tier}
+              slotColorVar={slotColorVar}
+              isSelected={expandedTier === tier.tierNumber}
+              onClick={() => setExpandedTier(expandedTier === tier.tierNumber ? null : tier.tierNumber)}
+            />
+            {/* MOBILE ONLY — inline panel appears directly below the clicked card */}
+            {expandedTier === tier.tierNumber && (
+              <div className="sm:hidden">
+                <ResultPanel tier={tier} slotColorVar={slotColorVar} />
+              </div>
+            )}
+          </Fragment>
         ))}
 
-        {/* Full-width panel below grid */}
+        {/* DESKTOP ONLY — full-width panel at the end of the grid row */}
         {expandedTier && (() => {
           const tier = sorted.find(t => t.tierNumber === expandedTier)
           if (!tier) return null
-          return <ResultPanel tier={tier} slotColorVar={slotColorVar} />
+          return (
+            <div className="hidden sm:block col-span-full">
+              <ResultPanel tier={tier} slotColorVar={slotColorVar} />
+            </div>
+          )
         })()}
       </div>
     </div>

--- a/app/schedule/ScheduleClient.js
+++ b/app/schedule/ScheduleClient.js
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, Fragment } from 'react'
 import { useRouter } from 'next/navigation'
 import { Clock, ChevronDown, Shield } from 'lucide-react'
 import LeagueSelector from '@/components/ui/LeagueSelector'
@@ -197,9 +197,6 @@ function MatchPanel({ tier, myTeam, slotColorVar, isMens }) {
                     isMyGame ? 'bg-titos-gold/[0.06] ring-1 ring-titos-gold/10' : 'bg-titos-elevated/40'
                   )}
                 >
-                  {/* Game number */}
-                  <span className="text-titos-gray-500 text-xs font-bold w-5 flex-shrink-0">{game.game}.</span>
-
                   {/* Home vs Away */}
                   <div className="flex items-center gap-1.5 flex-1 min-w-0">
                     <span className={cn('text-sm font-semibold truncate', homeWon ? 'text-titos-gold' : 'text-titos-white')}>
@@ -266,21 +263,32 @@ function SlotGroup({ slot, tiers, myTeam, isMens }) {
       {/* Grid + expanded panel */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2.5 sm:gap-3">
         {sorted.map((tier) => (
-          <TierCard
-            key={tier.tierNumber}
-            tier={tier}
-            myTeam={myTeam}
-            slotColorVar={slotColorVar}
-            isSelected={expandedTier === tier.tierNumber}
-            onClick={() => setExpandedTier(expandedTier === tier.tierNumber ? null : tier.tierNumber)}
-          />
+          <Fragment key={tier.tierNumber}>
+            <TierCard
+              tier={tier}
+              myTeam={myTeam}
+              slotColorVar={slotColorVar}
+              isSelected={expandedTier === tier.tierNumber}
+              onClick={() => setExpandedTier(expandedTier === tier.tierNumber ? null : tier.tierNumber)}
+            />
+            {/* MOBILE ONLY — inline panel appears directly below the clicked card */}
+            {expandedTier === tier.tierNumber && (
+              <div className="sm:hidden">
+                <MatchPanel tier={tier} myTeam={myTeam} slotColorVar={slotColorVar} isMens={isMens} />
+              </div>
+            )}
+          </Fragment>
         ))}
 
-        {/* Full-width match panel — renders INSIDE the grid as col-span-full */}
+        {/* DESKTOP ONLY — full-width panel at the end of the grid row */}
         {expandedTier && (() => {
           const tier = sorted.find(t => t.tierNumber === expandedTier)
           if (!tier) return null
-          return <MatchPanel tier={tier} myTeam={myTeam} slotColorVar={slotColorVar} isMens={isMens} />
+          return (
+            <div className="hidden sm:block col-span-full">
+              <MatchPanel tier={tier} myTeam={myTeam} slotColorVar={slotColorVar} isMens={isMens} />
+            </div>
+          )
         })()}
       </div>
     </div>


### PR DESCRIPTION
Mobile UX issue: clicking Tier 1 in the expanded tier grid caused the match panel to appear after Tier 4 (at the end of the slot group) because it was rendered as col-span-full inside the grid. Users had to scroll past unrelated tiers to see the matches for the one they tapped.

What changed
- Mobile only: MatchPanel/ResultPanel now renders inline directly below the clicked tier card using a Fragment and sm:hidden inline render
- Desktop unchanged: hidden sm:block col-span-full keeps the full-row panel below the grid row of 4 cards (correct for multi-column layout)
- Removed the "1." "2." ... numbering from each match row for a cleaner look