### PR TITLE
feat(mobile): drop redundant header + teams list from inline expand p…

### DIFF
--- a/app/results/ResultsClient.js
+++ b/app/results/ResultsClient.js
@@ -129,7 +129,7 @@ function TierCard({ tier, slotColorVar, isSelected, onClick }) {
 /* ═══════════════════════════════════════════════
    EXPANDED PANEL — full-width below grid
    ═══════════════════════════════════════════════ */
-function ResultPanel({ tier, slotColorVar }) {
+function ResultPanel({ tier, slotColorVar, compact = false }) {
   const teams = tier.teams || []
   const matches = tier.matches || []
   const stats = computeTeamStats(teams, matches)
@@ -147,19 +147,27 @@ function ResultPanel({ tier, slotColorVar }) {
       className="col-span-full rounded-xl overflow-hidden ring-1 ring-titos-gold/15 animate-fade-in"
       style={{ background: 'linear-gradient(180deg, rgba(242,165,39,0.03) 0%, rgba(17,17,17,1) 100%)' }}
     >
-      {/* Panel header */}
-      <div className="px-5 py-3 flex items-center justify-between border-b border-titos-border/20">
-        <div className="flex items-center gap-3">
-          <span className="font-display text-base font-black" style={{ color: `var(--color-${slotColorVar})` }}>
-            Tier {tier.tierNumber}
-          </span>
-          <span className="text-titos-gray-400 text-sm">Court {tier.courtNumber}</span>
+      {/* Panel header — hidden on compact (mobile inline) since tier card above shows it */}
+      {!compact && (
+        <div className="px-5 py-3 flex items-center justify-between border-b border-titos-border/20">
+          <div className="flex items-center gap-3">
+            <span className="font-display text-base font-black" style={{ color: `var(--color-${slotColorVar})` }}>
+              Tier {tier.tierNumber}
+            </span>
+            <span className="text-titos-gray-400 text-sm">Court {tier.courtNumber}</span>
+          </div>
         </div>
-      </div>
+      )}
 
-      <div className="p-5 flex flex-col lg:flex-row gap-6">
-        {/* Left: Team standings */}
-        <div className="lg:w-72 flex-shrink-0">
+      <div className={cn(
+        'p-5 flex flex-col lg:flex-row gap-6',
+        compact && 'pt-4 pb-4'
+      )}>
+        {/* Left: Team standings — hidden on compact (mobile inline) since tier card above shows W/L */}
+        <div className={cn(
+          'lg:w-72 flex-shrink-0',
+          compact && 'hidden'
+        )}>
           <span className="text-titos-gray-400 text-xs font-bold uppercase tracking-wider block mb-3">Standings</span>
           <div className="space-y-2">
             {sorted.map((t, idx) => {
@@ -278,7 +286,7 @@ function SlotGroup({ slot, tiers }) {
             {/* MOBILE ONLY — inline panel appears directly below the clicked card */}
             {expandedTier === tier.tierNumber && (
               <div className="sm:hidden">
-                <ResultPanel tier={tier} slotColorVar={slotColorVar} />
+                <ResultPanel tier={tier} slotColorVar={slotColorVar} compact />
               </div>
             )}
           </Fragment>

--- a/app/schedule/ScheduleClient.js
+++ b/app/schedule/ScheduleClient.js
@@ -111,7 +111,7 @@ function TierCard({ tier, myTeam, slotColorVar, isSelected, onClick }) {
 /* ═══════════════════════════════════════════════
    MATCH PANEL — full-width below the grid
    ═══════════════════════════════════════════════ */
-function MatchPanel({ tier, myTeam, slotColorVar, isMens }) {
+function MatchPanel({ tier, myTeam, slotColorVar, isMens, compact = false }) {
   const numRounds = isMens ? 3 : 2
   const teams = tier.teams || []
   const roundRobin = teams.length >= 3 ? generateRoundRobin(teams, numRounds) : []
@@ -131,19 +131,27 @@ function MatchPanel({ tier, myTeam, slotColorVar, isMens }) {
       className="col-span-full rounded-xl overflow-hidden ring-1 ring-titos-gold/15 animate-fade-in"
       style={{ background: 'linear-gradient(180deg, rgba(242,165,39,0.03) 0%, rgba(17,17,17,1) 100%)' }}
     >
-      {/* Panel header */}
-      <div className="px-5 py-3 flex items-center justify-between border-b border-titos-border/20">
-        <div className="flex items-center gap-3">
-          <span className="font-display text-base font-black" style={{ color: `var(--color-${slotColorVar})` }}>
-            Tier {tier.tierNumber}
-          </span>
-          <span className="text-titos-gray-400 text-sm">Court {tier.courtNumber}</span>
+      {/* Panel header — hidden on compact (mobile inline) since tier card above shows it */}
+      {!compact && (
+        <div className="px-5 py-3 flex items-center justify-between border-b border-titos-border/20">
+          <div className="flex items-center gap-3">
+            <span className="font-display text-base font-black" style={{ color: `var(--color-${slotColorVar})` }}>
+              Tier {tier.tierNumber}
+            </span>
+            <span className="text-titos-gray-400 text-sm">Court {tier.courtNumber}</span>
+          </div>
         </div>
-      </div>
+      )}
 
-      <div className="p-5 flex flex-col lg:flex-row gap-6">
-        {/* Left: Team roster */}
-        <div className="lg:w-56 flex-shrink-0">
+      <div className={cn(
+        'p-5 flex flex-col lg:flex-row gap-6',
+        compact && 'pt-4 pb-4'
+      )}>
+        {/* Left: Team roster — hidden on compact (mobile inline) since tier card above shows it */}
+        <div className={cn(
+          'lg:w-56 flex-shrink-0',
+          compact && 'hidden'
+        )}>
           <span className="text-titos-gray-400 text-xs font-bold uppercase tracking-wider block mb-3">Teams</span>
           <div className="space-y-2">
             {teams.map((t, idx) => {
@@ -274,7 +282,7 @@ function SlotGroup({ slot, tiers, myTeam, isMens }) {
             {/* MOBILE ONLY — inline panel appears directly below the clicked card */}
             {expandedTier === tier.tierNumber && (
               <div className="sm:hidden">
-                <MatchPanel tier={tier} myTeam={myTeam} slotColorVar={slotColorVar} isMens={isMens} />
+                <MatchPanel tier={tier} myTeam={myTeam} slotColorVar={slotColorVar} isMens={isMens} compact />
               </div>
             )}
           </Fragment>


### PR DESCRIPTION
…anel

On mobile the expanded panel renders directly below the clicked tier card, so the panel's own "Tier X / Court Y" header and teams roster just duplicate what the tier card above already shows. Added a 'compact' prop that hides those sections when the panel is rendered inline on mobile.

Desktop behavior unchanged — the full-row col-span-full panel still shows the header and teams list since it's detached from any single card.