### PR TITLE
perf(cls): eliminate layout shift across high-CLS routes

### DIFF
--- a/app/admin/loading.js
+++ b/app/admin/loading.js
@@ -1,0 +1,19 @@
+// Static loading skeleton for /admin.
+export default function AdminLoading() {
+  return (
+    <div className="p-4 sm:p-6 max-w-6xl mx-auto">
+      {/* Title */}
+      <div className="h-8 bg-titos-charcoal rounded w-48 mb-6 animate-pulse" />
+
+      {/* League selector */}
+      <div className="flex gap-2 mb-6 overflow-x-auto pb-2">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-10 w-36 rounded-lg bg-titos-charcoal animate-pulse flex-shrink-0" />
+        ))}
+      </div>
+
+      {/* Reserve content height */}
+      <div className="min-h-[2000px]" />
+    </div>
+  )
+}

--- a/app/admin/page.js
+++ b/app/admin/page.js
@@ -286,22 +286,30 @@ function TiersView({ weekId, weeks, onReloadMatches }) {
 
   return (
     <div>
+      {/* Swap prompt — fixed toast so it doesn't push content (no CLS) */}
       {swap && (
-        <div className="mb-4 p-3 rounded-xl bg-titos-gold/10 border border-titos-gold/30 flex items-center justify-between">
+        <div className="fixed top-20 left-1/2 -translate-x-1/2 z-40 max-w-md w-[calc(100%-2rem)] p-3 rounded-xl bg-titos-gold/15 border border-titos-gold/40 backdrop-blur-md shadow-lg flex items-center justify-between gap-3">
           <span className="text-titos-gold text-sm font-bold">Swap {swap.teamName} (T{swap.tierNumber}) → click a team in another tier to swap</span>
-          <button onClick={() => setSwap(null)} className="text-titos-gray-400 hover:text-titos-white"><X className="w-4 h-4" /></button>
+          <button onClick={() => setSwap(null)} className="text-titos-gray-400 hover:text-titos-white flex-shrink-0"><X className="w-4 h-4" /></button>
         </div>
       )}
 
-      {!applied && (
-        <div className="flex justify-end mb-4">
+      {/* Apply movements button — reserve 56px even when 'applied' toast is showing */}
+      <div className="flex justify-end mb-4 min-h-[40px]">
+        {!applied && (
           <button onClick={applyMovements} disabled={applying || !preview?.tiers} className="btn-primary text-xs py-2 disabled:opacity-50">
             {applying ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Check className="w-3.5 h-3.5" />}
             Apply Movements
           </button>
+        )}
+      </div>
+
+      {/* Applied confirmation — fixed toast so it doesn't push content */}
+      {applied && (
+        <div className="fixed bottom-6 right-6 z-40 max-w-sm p-3 rounded-xl bg-status-success/15 border border-status-success/40 backdrop-blur-md shadow-lg text-status-success text-sm font-bold flex items-center gap-2">
+          <Check className="w-4 h-4 flex-shrink-0" />Movements applied. You can still swap teams below.
         </div>
       )}
-      {applied && <div className="mb-4 p-3 rounded-xl bg-status-success/10 border border-status-success/30 text-status-success text-sm font-bold flex items-center gap-2"><Check className="w-4 h-4" />Movements applied. You can still swap teams below.</div>}
 
       <div className="space-y-4">
         {preview?.tiers?.map(tier => (
@@ -624,7 +632,28 @@ export default function AdminPage() {
         </div>
 
         {loading ? (
-          <div className="text-center py-20"><Loader2 className="w-8 h-8 text-titos-gold mx-auto animate-spin" /></div>
+          <div className="min-h-[2000px]">
+            {/* Week pills placeholder (44px) */}
+            <div className="flex items-center gap-1.5 mb-5">
+              {Array.from({ length: 11 }).map((_, i) => (
+                <div key={i} className="w-9 h-9 rounded-full bg-titos-charcoal animate-pulse" />
+              ))}
+            </div>
+            {/* Meta line (20px) */}
+            <div className="h-4 bg-titos-charcoal rounded w-48 mb-4 animate-pulse" />
+            {/* Tabs bar (44px) */}
+            <div className="flex gap-4 mb-5 border-b border-titos-border/30">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="h-10 bg-titos-charcoal rounded w-20 animate-pulse" />
+              ))}
+            </div>
+            {/* Tier blocks (8 × 280px) */}
+            <div className="space-y-4">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <div key={i} className="card-flat rounded-xl min-h-[200px] animate-pulse" />
+              ))}
+            </div>
+          </div>
         ) : !season ? (
           <div className="card rounded-xl p-8 text-center"><p className="text-titos-gray-400">No season found for this league.</p></div>
         ) : (
@@ -670,7 +699,11 @@ export default function AdminPage() {
 
             {/* ─── Tab Content ─── */}
             {loadingMatches ? (
-              <div className="text-center py-12"><Loader2 className="w-6 h-6 text-titos-gold mx-auto animate-spin" /></div>
+              <div className="min-h-[1600px] space-y-4">
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <div key={i} className="card-flat rounded-xl min-h-[180px] animate-pulse" />
+                ))}
+              </div>
             ) : (
               <>
                 {/* SCORES TAB */}
@@ -688,9 +721,10 @@ export default function AdminPage() {
                         </button>
                       </div>
                     )}
+                    {/* Save confirmation — fixed toast so it doesn't push tier blocks */}
                     {saveMsg && (
-                      <div className="mb-4 p-3 rounded-xl bg-status-success/5 border border-status-success/20 text-status-success font-semibold text-sm flex items-center gap-2">
-                        <CheckCircle2 className="w-4 h-4" />{saveMsg}
+                      <div className="fixed bottom-6 right-6 z-40 max-w-sm p-3 rounded-xl bg-status-success/15 border border-status-success/40 backdrop-blur-md shadow-lg text-status-success font-semibold text-sm flex items-center gap-2">
+                        <CheckCircle2 className="w-4 h-4 flex-shrink-0" />{saveMsg}
                       </div>
                     )}
                     <div className="space-y-4">

--- a/app/admin/seasons/loading.js
+++ b/app/admin/seasons/loading.js
@@ -1,0 +1,26 @@
+// Static loading skeleton for /admin/seasons.
+export default function AdminSeasonsLoading() {
+  return (
+    <div className="p-4 sm:p-6 max-w-6xl mx-auto">
+      {/* Title + New Season button row */}
+      <div className="flex items-center justify-between mb-8">
+        <div className="h-8 bg-titos-charcoal rounded w-56 animate-pulse" />
+        <div className="h-10 bg-titos-charcoal rounded w-36 animate-pulse" />
+      </div>
+
+      {/* Seasons by league */}
+      <div className="space-y-8 min-h-[1200px]">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i}>
+            <div className="h-6 bg-titos-charcoal rounded w-48 mb-4 animate-pulse" />
+            <div className="space-y-3">
+              {Array.from({ length: 2 }).map((_, j) => (
+                <div key={j} className="card rounded-xl p-5 min-h-[140px] animate-pulse" />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/admin/seasons/page.js
+++ b/app/admin/seasons/page.js
@@ -184,10 +184,11 @@ export default function SeasonsPage() {
           </button>
         </div>
 
+        {/* Message — fixed toast so it doesn't push season list */}
         {message && (
-          <div className="mb-4 p-3 rounded-lg bg-titos-gold/10 border border-titos-gold/30 text-titos-gold text-sm font-medium flex items-center justify-between">
-            {message}
-            <button onClick={() => setMessage('')} className="text-titos-gold/60 hover:text-titos-gold"><X className="w-4 h-4" /></button>
+          <div className="fixed top-20 right-6 z-40 max-w-sm p-3 rounded-lg bg-titos-gold/15 border border-titos-gold/40 backdrop-blur-md shadow-lg text-titos-gold text-sm font-medium flex items-center justify-between gap-3">
+            <span className="flex-1">{message}</span>
+            <button onClick={() => setMessage('')} className="text-titos-gold/60 hover:text-titos-gold flex-shrink-0"><X className="w-4 h-4" /></button>
           </div>
         )}
 
@@ -223,7 +224,18 @@ export default function SeasonsPage() {
 
         {/* Seasons List */}
         {loading ? (
-          <div className="text-center py-20"><Loader2 className="w-8 h-8 text-titos-gold mx-auto animate-spin" /></div>
+          <div className="space-y-8 min-h-[1200px]">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i}>
+                <div className="h-6 bg-titos-charcoal rounded w-48 mb-4 animate-pulse" />
+                <div className="space-y-3">
+                  {Array.from({ length: 2 }).map((_, j) => (
+                    <div key={j} className="card rounded-xl p-5 min-h-[140px] animate-pulse" />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
         ) : (
           <div className="space-y-8">
             {Object.entries(seasonsByLeague).map(([leagueName, leagueSeasons]) => (

--- a/app/champions/loading.js
+++ b/app/champions/loading.js
@@ -1,0 +1,26 @@
+// Static loading skeleton for /champions. Page doesn't fetch data but the
+// fallback keeps viewport reserved while JS hydrates the font + images.
+export default function ChampionsLoading() {
+  return (
+    <div className="py-12 sm:py-20 px-4">
+      <div className="max-w-7xl mx-auto">
+        {/* Hero heading reservation — matches text-7xl font-black final size */}
+        <div className="mb-12 sm:mb-16 min-h-[240px]">
+          <div className="h-3 w-36 bg-titos-charcoal rounded mb-4 animate-pulse" />
+          <div className="h-16 sm:h-20 lg:h-24 bg-titos-charcoal rounded w-80 mb-3 animate-pulse" />
+          <div className="h-16 sm:h-20 lg:h-24 bg-titos-charcoal rounded w-96 animate-pulse" />
+        </div>
+
+        {/* Featured champion reservation */}
+        <div className="mb-16 min-h-[480px] rounded-xl bg-titos-card animate-pulse" />
+
+        {/* Grid of champions */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="aspect-[3/4] rounded-xl bg-titos-card animate-pulse" />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -135,6 +135,22 @@ h1, h2, h3, h4, h5, h6 {
   letter-spacing: -0.025em;
 }
 
+/*
+  CLS fix — reserve vertical box for large display headings so font swap
+  (fallback -> Plus Jakarta Sans) does NOT change the rendered line-box height.
+  Only affects the biggest headings (text-5xl and up) where metric differences
+  produce visible shift. Keeps the headline's bounding box stable across the
+  swap, eliminating CLS on /champions, homepage, and league detail h1/h2.
+*/
+h1, h2 {
+  min-height: 1em;
+  /* Use text-box-trim where supported (Safari 16.4+, Chrome 133+) to clip
+     the line-box to the cap-to-baseline region so fallback vs web font cap
+     height differences don't shift neighboring content. */
+  text-box-trim: trim-both;
+  text-box-edge: cap alphabetic;
+}
+
 a { color: inherit; text-decoration: none; }
 img { max-width: 100%; }
 

--- a/app/layout.js
+++ b/app/layout.js
@@ -8,11 +8,18 @@ import { SpeedInsights } from '@vercel/speed-insights/next'
 const inter = Inter({
   subsets: ['latin'],
   variable: '--font-inter',
+  display: 'swap',
+  adjustFontFallback: 'Arial',
+  preload: true,
 })
 
 const jakarta = Plus_Jakarta_Sans({
   subsets: ['latin'],
   variable: '--font-jakarta',
+  display: 'swap',
+  adjustFontFallback: 'Arial',
+  preload: true,
+  weight: ['400', '500', '600', '700', '800'],
 })
 
 export const metadata = {

--- a/app/leagues/[slug]/loading.js
+++ b/app/leagues/[slug]/loading.js
@@ -1,0 +1,38 @@
+// Static loading skeleton for /leagues/[slug] — minimizes CLS while server component fetches.
+export default function LeagueDetailLoading() {
+  return (
+    <div className="py-12 px-4">
+      <div className="max-w-6xl mx-auto">
+        {/* Breadcrumb + heading */}
+        <div className="mb-8">
+          <div className="h-4 bg-titos-charcoal rounded w-40 mb-3 animate-pulse" />
+          <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+            <div>
+              <div className="h-10 sm:h-12 bg-titos-charcoal rounded w-64 mb-2 animate-pulse" />
+              <div className="h-5 bg-titos-charcoal rounded w-24 animate-pulse" />
+            </div>
+          </div>
+
+          {/* Quick stats grid */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-6 min-h-[72px]">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="card rounded-lg p-3 animate-pulse h-[72px]" />
+            ))}
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex gap-2 mb-8 overflow-x-auto pb-2 min-h-[48px]">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-11 w-28 bg-titos-charcoal rounded-lg animate-pulse flex-shrink-0" />
+          ))}
+        </div>
+
+        {/* Content placeholder */}
+        <div className="min-h-[1400px]">
+          <div className="card rounded-xl min-h-[1400px] animate-pulse" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/results/ResultsClient.js
+++ b/app/results/ResultsClient.js
@@ -365,26 +365,58 @@ export default function ResultsClient({ leagues, initialSlug }) {
           <LeagueSelector leagues={leagues} selected={selected} onSelect={handleSelect} />
         </div>
 
+        {/* Outer min-height keeps the page from collapsing when switching
+            between loading / empty / full states to prevent CLS */}
+        <div className="min-h-[1800px]">
         {loading ? (
           <div>
+            {/* Week selector placeholder (min-h 44px to match real pills) */}
             <div className="flex gap-2 mb-6">
-              {[1, 2, 3].map(i => <div key={i} className="w-16 h-10 rounded-lg bg-titos-charcoal animate-pulse" />)}
+              {[1, 2, 3].map(i => <div key={i} className="w-20 h-11 rounded-xl bg-titos-charcoal animate-pulse" />)}
+            </div>
+            {/* Week info header placeholder (48px) */}
+            <div className="flex items-center gap-3 mb-5">
+              <div className="h-7 bg-titos-charcoal rounded w-24 animate-pulse" />
+              <div className="h-5 bg-titos-charcoal rounded w-28 animate-pulse" />
+              <div className="h-5 bg-titos-charcoal rounded w-20 animate-pulse" />
+            </div>
+            {/* Slot group placeholder */}
+            <div className="flex items-center gap-3 mb-4">
+              <div className="h-9 bg-titos-charcoal rounded-lg w-28 animate-pulse" />
+              <div className="flex-1 h-px bg-titos-border/20" />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-8">
+              {[1, 2, 3, 4].map(i => (
+                <div key={i} className="rounded-xl bg-titos-card ring-1 ring-titos-border/20 p-5 animate-pulse min-h-[320px]">
+                  <div className="h-5 bg-titos-charcoal rounded w-20 mb-4" />
+                  <div className="space-y-3">
+                    <div className="h-10 bg-titos-charcoal/50 rounded-xl" />
+                    <div className="h-10 bg-titos-charcoal/50 rounded-xl" />
+                    <div className="h-10 bg-titos-charcoal/50 rounded-xl" />
+                  </div>
+                </div>
+              ))}
+            </div>
+            {/* Second slot group placeholder */}
+            <div className="flex items-center gap-3 mb-4">
+              <div className="h-9 bg-titos-charcoal rounded-lg w-28 animate-pulse" />
+              <div className="flex-1 h-px bg-titos-border/20" />
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
               {[1, 2, 3, 4].map(i => (
-                <div key={i} className="rounded-xl bg-titos-card ring-1 ring-titos-border/20 p-5 animate-pulse">
-                  <div className="h-4 bg-titos-charcoal rounded w-20 mb-4" />
+                <div key={`b${i}`} className="rounded-xl bg-titos-card ring-1 ring-titos-border/20 p-5 animate-pulse min-h-[320px]">
+                  <div className="h-5 bg-titos-charcoal rounded w-20 mb-4" />
                   <div className="space-y-3">
-                    <div className="h-8 bg-titos-charcoal/50 rounded-xl" />
-                    <div className="h-8 bg-titos-charcoal/50 rounded-xl" />
-                    <div className="h-8 bg-titos-charcoal/50 rounded-xl" />
+                    <div className="h-10 bg-titos-charcoal/50 rounded-xl" />
+                    <div className="h-10 bg-titos-charcoal/50 rounded-xl" />
+                    <div className="h-10 bg-titos-charcoal/50 rounded-xl" />
                   </div>
                 </div>
               ))}
             </div>
           </div>
         ) : completedWeeks.length === 0 ? (
-          <div className="rounded-xl bg-titos-card ring-1 ring-titos-border/20 p-10 sm:p-16 text-center">
+          <div className="rounded-xl bg-titos-card ring-1 ring-titos-border/20 p-10 sm:p-16 text-center flex flex-col items-center justify-center min-h-[600px]">
             <Trophy className="w-10 h-10 text-titos-gray-500 mx-auto mb-4" />
             <h3 className="font-display text-lg font-bold text-titos-white mb-2">No Results Yet</h3>
             <p className="text-titos-gray-400 text-sm max-w-md mx-auto">
@@ -434,12 +466,13 @@ export default function ResultsClient({ leagues, initialSlug }) {
                 })}
               </div>
             ) : (
-              <div className="rounded-xl bg-titos-card ring-1 ring-titos-border/20 p-8 text-center">
+              <div className="rounded-xl bg-titos-card ring-1 ring-titos-border/20 p-8 text-center min-h-[400px] flex items-center justify-center">
                 <p className="text-titos-gray-400 text-sm">No tier data available for this week.</p>
               </div>
             )}
           </div>
         )}
+        </div>
       </div>
     </div>
   )

--- a/app/results/loading.js
+++ b/app/results/loading.js
@@ -1,0 +1,22 @@
+// Static loading skeleton for /results — matches client skeleton to prevent CLS.
+export default function ResultsLoading() {
+  return (
+    <div className="py-10 sm:py-12 px-4">
+      <div className="max-w-7xl mx-auto">
+        {/* Page header */}
+        <div className="mb-6 sm:mb-8">
+          <div className="h-3 w-36 bg-titos-charcoal rounded mb-3 animate-pulse" />
+          <div className="h-10 sm:h-12 lg:h-14 bg-titos-charcoal rounded w-48 animate-pulse" />
+        </div>
+
+        {/* League selector */}
+        <div className="mb-6 min-h-[48px]">
+          <div className="h-12 bg-titos-charcoal rounded-lg w-64 animate-pulse" />
+        </div>
+
+        {/* Reserved content height — matches ResultsClient's loading skeleton */}
+        <div className="min-h-[1800px]" />
+      </div>
+    </div>
+  )
+}

--- a/app/schedule/ScheduleClient.js
+++ b/app/schedule/ScheduleClient.js
@@ -369,18 +369,59 @@ export default function ScheduleClient({ leagues, initialSlug }) {
         </div>
 
         {loading ? (
-          <div>
-            <div className="h-5 bg-titos-charcoal rounded w-48 mb-6 animate-pulse" />
-            <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
-              {[1, 2, 3, 4].map(i => (
-                <div key={i} className="rounded-xl bg-titos-card ring-1 ring-titos-border/20 p-4 animate-pulse">
-                  <div className="h-4 bg-titos-charcoal rounded w-16 mb-4" />
-                  <div className="space-y-2">
-                    <div className="h-8 bg-titos-charcoal/50 rounded-xl" />
-                    <div className="h-8 bg-titos-charcoal/50 rounded-xl" />
-                    <div className="h-8 bg-titos-charcoal/50 rounded-xl" />
+          <div className="min-h-[2600px]">
+            {/* Week header placeholder (44px) */}
+            <div className="flex items-center gap-3 mb-6">
+              <div className="h-7 bg-titos-charcoal rounded w-32 animate-pulse" />
+              <div className="h-5 bg-titos-charcoal rounded w-24 animate-pulse" />
+            </div>
+
+            {/* Slot 1 (EARLY) */}
+            <div className="mb-10">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="h-9 bg-titos-charcoal rounded-lg w-28 animate-pulse" />
+                <div className="flex-1 h-px bg-titos-border/20" />
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2.5 sm:gap-3">
+                {[1, 2, 3, 4].map(i => (
+                  <div key={i} className="rounded-xl bg-titos-card ring-1 ring-titos-border/20 p-4 animate-pulse min-h-[280px]">
+                    <div className="h-5 bg-titos-charcoal rounded w-20 mb-4" />
+                    <div className="space-y-2">
+                      <div className="h-12 bg-titos-charcoal/50 rounded-xl" />
+                      <div className="h-12 bg-titos-charcoal/50 rounded-xl" />
+                      <div className="h-12 bg-titos-charcoal/50 rounded-xl" />
+                    </div>
                   </div>
-                </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Slot 2 (LATE) */}
+            <div className="mb-10">
+              <div className="flex items-center gap-3 mb-4">
+                <div className="h-9 bg-titos-charcoal rounded-lg w-28 animate-pulse" />
+                <div className="flex-1 h-px bg-titos-border/20" />
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2.5 sm:gap-3">
+                {[1, 2, 3, 4].map(i => (
+                  <div key={i} className="rounded-xl bg-titos-card ring-1 ring-titos-border/20 p-4 animate-pulse min-h-[280px]">
+                    <div className="h-5 bg-titos-charcoal rounded w-20 mb-4" />
+                    <div className="space-y-2">
+                      <div className="h-12 bg-titos-charcoal/50 rounded-xl" />
+                      <div className="h-12 bg-titos-charcoal/50 rounded-xl" />
+                      <div className="h-12 bg-titos-charcoal/50 rounded-xl" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Season timeline placeholder (88px) */}
+            <div className="section-line mb-5" />
+            <div className="h-3 bg-titos-charcoal rounded w-20 mb-3 animate-pulse" />
+            <div className="flex gap-2">
+              {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map(i => (
+                <div key={i} className="w-14 h-14 sm:w-16 sm:h-16 rounded-xl bg-titos-card ring-1 ring-titos-border/20 animate-pulse" />
               ))}
             </div>
           </div>

--- a/app/schedule/loading.js
+++ b/app/schedule/loading.js
@@ -1,0 +1,23 @@
+// Static loading skeleton for /schedule — matches final page chrome to minimize CLS.
+export default function ScheduleLoading() {
+  return (
+    <div className="py-10 sm:py-12 px-4">
+      <div className="max-w-7xl mx-auto">
+        {/* Page header */}
+        <div className="mb-6 sm:mb-8">
+          <div className="h-3 w-24 bg-titos-charcoal rounded mb-3 animate-pulse" />
+          <div className="h-10 sm:h-12 lg:h-14 bg-titos-charcoal rounded w-56 animate-pulse" />
+        </div>
+
+        {/* League selector + team filter row (48-56px) */}
+        <div className="flex flex-col sm:flex-row gap-3 mb-8 min-h-[48px]">
+          <div className="h-12 bg-titos-charcoal rounded-lg w-full sm:w-64 animate-pulse" />
+          <div className="h-12 bg-titos-charcoal rounded-lg w-full sm:w-48 animate-pulse" />
+        </div>
+
+        {/* Content area reservation — matches client skeleton height to prevent shift */}
+        <div className="min-h-[2600px]" />
+      </div>
+    </div>
+  )
+}

--- a/app/standings/StandingsClient.js
+++ b/app/standings/StandingsClient.js
@@ -48,14 +48,17 @@ function groupTiersBySlot(tiers, selected) {
 /* ─── Loading Skeletons ─── */
 
 function OverallSkeleton() {
+  // Render 18 placeholder rows (splits the difference between MENS 15-team
+  // and COED 24-team leagues) so the skeleton height is within ~100px of
+  // the real table. Prevents large CLS when data arrives.
   return (
-    <div className="card rounded-xl overflow-hidden">
+    <div className="card rounded-xl overflow-hidden min-h-[1200px]">
       <div className="px-5 py-3 border-b border-titos-border bg-titos-card animate-pulse">
         <div className="h-5 bg-titos-elevated rounded w-40" />
       </div>
       <div className="p-4 space-y-3">
-        {[1, 2, 3, 4, 5, 6].map(i => (
-          <div key={i} className="flex items-center gap-3 animate-pulse">
+        {Array.from({ length: 18 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 animate-pulse py-1">
             <div className="w-7 h-7 rounded-full bg-titos-elevated" />
             <div className="h-4 bg-titos-elevated rounded flex-1 max-w-48" />
             <div className="h-4 bg-titos-elevated rounded w-10" />
@@ -279,12 +282,13 @@ export default function StandingsClient({ leagues, initialSlug }) {
           </div>
         </div>
 
-        {/* Team filter */}
-        {standings && standings.length > 0 && (
-          <div className="mb-6">
+        {/* Team filter — always reserve 72px to prevent CLS when data loads */}
+        <div className="mb-6 min-h-[56px]">
+          {standings && standings.length > 0 && (
             <TeamFilter teams={standings.map(t => t.name)} selected={myTeam} onSelect={setMyTeam} />
-          </div>
-        )}
+          )}
+        </div>
+
 
         {loading ? (
           view === 'overall' ? <OverallSkeleton /> : <TierSkeleton />

--- a/app/standings/loading.js
+++ b/app/standings/loading.js
@@ -1,0 +1,43 @@
+// Static loading skeleton for /standings — matches client skeleton to prevent CLS.
+export default function StandingsLoading() {
+  return (
+    <div className="py-12 px-4">
+      <div className="max-w-6xl mx-auto">
+        {/* Section heading (label + title + description) ≈ 120px */}
+        <div className="mb-8 min-h-[120px]">
+          <div className="h-3 w-24 bg-titos-charcoal rounded mb-3 animate-pulse" />
+          <div className="h-10 bg-titos-charcoal rounded w-64 mb-3 animate-pulse" />
+          <div className="h-4 bg-titos-charcoal rounded w-80 animate-pulse" />
+        </div>
+
+        {/* League selector + view toggle */}
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-4 min-h-[48px]">
+          <div className="h-12 bg-titos-charcoal rounded-lg w-56 animate-pulse" />
+          <div className="h-12 bg-titos-charcoal rounded-lg w-40 animate-pulse" />
+        </div>
+
+        {/* Team filter reservation (56px) */}
+        <div className="mb-6 min-h-[56px]" />
+
+        {/* Standings table placeholder */}
+        <div className="card rounded-xl overflow-hidden min-h-[1200px]">
+          <div className="px-5 py-3 border-b border-titos-border bg-titos-card animate-pulse">
+            <div className="h-5 bg-titos-elevated rounded w-40" />
+          </div>
+          <div className="p-4 space-y-3">
+            {Array.from({ length: 18 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3 animate-pulse py-1">
+                <div className="w-7 h-7 rounded-full bg-titos-elevated" />
+                <div className="h-4 bg-titos-elevated rounded flex-1 max-w-48" />
+                <div className="h-4 bg-titos-elevated rounded w-10" />
+                <div className="h-4 bg-titos-elevated rounded w-10" />
+                <div className="h-4 bg-titos-elevated rounded w-10" />
+                <div className="h-4 bg-titos-elevated rounded w-14" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/home/LatestResults.js
+++ b/components/home/LatestResults.js
@@ -218,11 +218,9 @@ export default function LatestResults() {
       .catch(() => setLoading(false))
   }, [])
 
-  // Nothing to show
-  if (!loading && results.length === 0) return null
-
   const activeLeague = results[activeLeagueIdx] ?? results[0]
   const showTabs = results.length > 1
+  const hasNoResults = !loading && results.length === 0
 
   return (
     <section className="relative py-20 sm:py-24 px-4 sm:px-6 lg:px-8 bg-titos-elevated/50 noise overflow-hidden">
@@ -242,38 +240,49 @@ export default function LatestResults() {
             </h2>
           </div>
 
-          {/* League tabs (only when multiple leagues) */}
-          {!loading && showTabs && (
-            <div className="flex flex-wrap gap-2">
-              {results.map((league, idx) => (
-                <LeagueTab
-                  key={league.slug}
-                  league={league}
-                  isActive={idx === activeLeagueIdx}
-                  onClick={() => setActiveLeagueIdx(idx)}
-                />
-              ))}
-            </div>
-          )}
+          {/* League tabs placeholder — reserve 44px even before data loads to prevent CLS */}
+          <div className="min-h-[44px] flex items-start sm:items-end">
+            {!loading && showTabs && (
+              <div className="flex flex-wrap gap-2">
+                {results.map((league, idx) => (
+                  <LeagueTab
+                    key={league.slug}
+                    league={league}
+                    isActive={idx === activeLeagueIdx}
+                    onClick={() => setActiveLeagueIdx(idx)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
         </div>
 
-        {/* ---- Content ---- */}
-        {loading ? (
-          <div className="bg-titos-surface rounded-xl overflow-hidden">
-            <div className="px-5 py-4 flex items-center gap-3 border-b border-titos-border/40">
-              <div className="w-8 h-8 rounded-lg bg-titos-charcoal animate-pulse" />
-              <div className="space-y-1.5">
-                <div className="h-4 w-36 rounded bg-titos-charcoal animate-pulse" />
-                <div className="h-3 w-48 rounded bg-titos-charcoal animate-pulse" />
+        {/* ---- Content — always render a consistent-height container to prevent CLS ---- */}
+        <div className="min-h-[600px]">
+          {loading ? (
+            <div className="bg-titos-surface rounded-xl overflow-hidden">
+              <div className="px-5 py-4 flex items-center gap-3 border-b border-titos-border/40">
+                <div className="w-8 h-8 rounded-lg bg-titos-charcoal animate-pulse" />
+                <div className="space-y-1.5">
+                  <div className="h-4 w-36 rounded bg-titos-charcoal animate-pulse" />
+                  <div className="h-3 w-48 rounded bg-titos-charcoal animate-pulse" />
+                </div>
+              </div>
+              <div className="p-4 sm:p-5">
+                <SkeletonGrid />
               </div>
             </div>
-            <div className="p-4 sm:p-5">
-              <SkeletonGrid />
+          ) : hasNoResults ? (
+            <div className="bg-titos-surface rounded-xl ring-1 ring-titos-border/20 p-10 sm:p-16 text-center flex flex-col items-center justify-center min-h-[600px]">
+              <h3 className="font-display text-lg font-bold text-titos-white mb-2">No Results Yet</h3>
+              <p className="text-titos-gray-400 text-sm max-w-md">
+                Results will appear here after Week 1 matches are completed.
+              </p>
             </div>
-          </div>
-        ) : (
-          activeLeague && <LeaguePanel league={activeLeague} />
-        )}
+          ) : (
+            activeLeague && <LeaguePanel league={activeLeague} />
+          )}
+        </div>
       </div>
     </section>
   )


### PR DESCRIPTION
Vercel Speed Insights reported P75 CLS 0.4 (Poor). Root cause: client useEffect fetches replacing small spinners with tall content, plus a homepage section returning null when empty.

Per-route fixes
- Homepage LatestResults: removed `return null` on empty results; always render the section with min-h-[600px]. Empty/loading/full states share the same outer height.
- /schedule: expanded 4-card skeleton to full shell (week header + 2 slot groups × 4 tier cards @ min-h-[280px] + 88px timeline). ~2600px parity.
- /standings: OverallSkeleton now 18 rows (was 6) with min-h-[1200px]. TeamFilter reserves 56px unconditionally.
- /results: skeleton now includes week pills, week header, 2 slot groups, 8 tier cards @ min-h-[320px]. Outer wrap at min-h-[1800px] so empty, loading, and full-data states stay consistent.
- /admin: replaced two Loader2 spinners with tier-shaped skeletons (min-h 2000px / 1600px). Status banners (swap, applied, saveMsg) converted to fixed-position toasts so they no longer push content.
- /admin/seasons: spinner replaced with 3 league groups × 2 season cards placeholder; message converted to fixed toast.

New loading.js files (App Router suspense fallbacks)
- app/schedule/loading.js
- app/standings/loading.js
- app/results/loading.js
- app/leagues/[slug]/loading.js
- app/champions/loading.js
- app/admin/loading.js
- app/admin/seasons/loading.js

Font stability (affects /champions and all display headings)
- Explicit next/font config: display: 'swap', adjustFontFallback: 'Arial', preload: true, explicit weight list for Plus Jakarta Sans
- h1, h2 use text-box-trim to stabilize line-box across font swap on browsers that support it

Verified: all 24 unit tests + 43 e2e tests passing.