### PR TITLE
fix(prisma): add PRISMA_DATABASE_URL to connection fallback chain

### DIFF
--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -8,10 +8,13 @@ import { PrismaPg } from "@prisma/adapter-pg";
 const globalForPrisma = globalThis;
 
 function createClient() {
-  // Prefer the pooled connection URL provided by Vercel Postgres integration
-  // (POSTGRES_PRISMA_URL routes through PgBouncer), fall back to DATABASE_URL.
+  // Prefer the pooled connection URL. Covers both common hosting conventions:
+  //   - Vercel Postgres integration sets POSTGRES_PRISMA_URL (via PgBouncer)
+  //   - Prisma Postgres (db.prisma.io) sets PRISMA_DATABASE_URL
+  // Fall back to DATABASE_URL for local dev and generic setups.
   let connectionString =
     process.env.POSTGRES_PRISMA_URL ||
+    process.env.PRISMA_DATABASE_URL ||
     process.env.DATABASE_URL ||
     '';
 


### PR DESCRIPTION
Prisma Postgres (db.prisma.io) sets PRISMA_DATABASE_URL as its env var name, distinct from Vercel Postgres' POSTGRES_PRISMA_URL. Chain is now:
  POSTGRES_PRISMA_URL  (Vercel Postgres)
  -> PRISMA_DATABASE_URL (Prisma Postgres / db.prisma.io)
  -> DATABASE_URL        (generic fallback)