### PR TITLE
fix: timezone bug, sunday MENS tiebreakers, and 2-division split

### DIFF
--- a/app/admin/tournaments/[slug]/page.js
+++ b/app/admin/tournaments/[slug]/page.js
@@ -34,6 +34,21 @@ function toLocalInput(iso) {
   return local.toISOString().slice(0, 16)
 }
 
+// Inverse of toLocalInput. <input type="datetime-local"> returns a bare
+// "YYYY-MM-DDTHH:mm" string with no timezone designator. The browser's Date
+// constructor interprets that as *local time* (which is what the admin typed),
+// so .toISOString() produces the correct UTC instant.
+//
+// If we skip this step and send the raw string to the server, `new Date(str)`
+// on a UTC-runtime server (Vercel) parses it as UTC — shifting the saved time
+// by the admin's TZ offset (e.g. EST admin types 10:00, DB ends up with 10:00
+// UTC = 6:00 EST). Convert here so the server never has to guess.
+function localInputToISO(value) {
+  if (!value) return null
+  const d = new Date(value)
+  return Number.isNaN(d.getTime()) ? null : d.toISOString()
+}
+
 function ConfigForm({ tournament, onSaved }) {
   const [form, setForm] = useState({
     name: tournament.name,
@@ -55,7 +70,15 @@ function ConfigForm({ tournament, onSaved }) {
     e.preventDefault()
     setBusy(true); setMsg('')
     try {
-      const res = await adminPatch(`/api/admin/tournaments/${tournament.slug}`, form)
+      // Convert datetime-local strings from "admin's local time" to proper UTC
+      // ISO before sending. Otherwise the server (Vercel = UTC) treats them as
+      // UTC and the stored time is off by the admin's TZ offset.
+      const payload = {
+        ...form,
+        date: localInputToISO(form.date),
+        endDate: form.endDate ? localInputToISO(form.endDate) : null,
+      }
+      const res = await adminPatch(`/api/admin/tournaments/${tournament.slug}`, payload)
       if (!res.ok) {
         const d = await res.json()
         setMsg(d.error || 'Failed to save')

--- a/app/admin/tournaments/page.js
+++ b/app/admin/tournaments/page.js
@@ -8,6 +8,17 @@ import { adminFetch, adminPost, adminDelete } from '@/lib/adminFetch'
 import StatusBadge from '@/components/ui/StatusBadge'
 import { formatDate } from '@/lib/utils'
 
+// <input type="datetime-local"> returns "YYYY-MM-DDTHH:mm" with no timezone.
+// The browser's Date constructor parses that as *local time* (what the admin
+// typed), so .toISOString() yields the correct UTC instant. Without this
+// conversion, the UTC-runtime server (Vercel) parses the raw string as UTC
+// and shifts the stored time by the admin's TZ offset.
+function localInputToISO(value) {
+  if (!value) return null
+  const d = new Date(value)
+  return Number.isNaN(d.getTime()) ? null : d.toISOString()
+}
+
 function CreateTournamentForm({ onCreated }) {
   const [open, setOpen] = useState(false)
   const [busy, setBusy] = useState(false)
@@ -21,7 +32,14 @@ function CreateTournamentForm({ onCreated }) {
     e.preventDefault()
     setBusy(true); setErr('')
     try {
-      const res = await adminPost('/api/admin/tournaments', form)
+      // Convert local-time inputs to proper UTC ISO before sending so the
+      // server-side `new Date(...)` can't re-interpret them as UTC.
+      const payload = {
+        ...form,
+        date: localInputToISO(form.date),
+        endDate: form.endDate ? localInputToISO(form.endDate) : null,
+      }
+      const res = await adminPost('/api/admin/tournaments', payload)
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'Failed to create')
       onCreated()

--- a/app/api/admin/tier-movement/route.js
+++ b/app/api/admin/tier-movement/route.js
@@ -15,7 +15,13 @@ export async function POST(request) {
     const week = await prisma.week.findUnique({
       where: { id: weekId },
       include: {
-        season: { include: { tiers: { orderBy: { tierNumber: 'asc' } } } },
+        season: {
+          include: {
+            tiers: { orderBy: { tierNumber: 'asc' } },
+            // League slug decides which tiebreaker cascade to apply.
+            league: { select: { slug: true } },
+          },
+        },
         matches: {
           where: { status: 'completed' },
           include: { scores: true },
@@ -30,6 +36,23 @@ export async function POST(request) {
     })
 
     if (!week) return NextResponse.json({ error: 'Week not found' }, { status: 404 })
+
+    // Head-to-head point diff, built once per week from the raw scores.
+    // h2h[a][b] = A's net points across every set A played against B this week.
+    // Only consulted as a tiebreaker for Sunday MENS (3 sets per matchup gives
+    // a meaningful sample — see lib/server/leagues.js for the matching rule on
+    // season standings).
+    const h2h = {}
+    for (const match of week.matches) {
+      for (const score of match.scores) {
+        const diff = score.homeScore - score.awayScore
+        if (!h2h[match.homeTeamId]) h2h[match.homeTeamId] = {}
+        if (!h2h[match.awayTeamId]) h2h[match.awayTeamId] = {}
+        h2h[match.homeTeamId][match.awayTeamId] = (h2h[match.homeTeamId][match.awayTeamId] || 0) + diff
+        h2h[match.awayTeamId][match.homeTeamId] = (h2h[match.awayTeamId][match.homeTeamId] || 0) - diff
+      }
+    }
+    const useHeadToHead = week.season.league?.slug === 'sunday-mens'
 
     // Group placements by tier
     const tierData = {}
@@ -60,8 +83,16 @@ export async function POST(request) {
         team.pointDiff = pointDiff
       }
 
-      // Sort: sets won desc, then point diff desc
-      data.teams.sort((a, b) => b.setsWon - a.setsWon || b.pointDiff - a.pointDiff)
+      // Sort: sets won desc, then (Sunday MENS only) head-to-head, then point diff desc.
+      // COED leagues stick with the legacy setsWon → pointDiff rule on purpose.
+      data.teams.sort((a, b) => {
+        if (b.setsWon !== a.setsWon) return b.setsWon - a.setsWon
+        if (useHeadToHead) {
+          const h = (h2h[b.id]?.[a.id] ?? 0) - (h2h[a.id]?.[b.id] ?? 0)
+          if (h !== 0) return h
+        }
+        return b.pointDiff - a.pointDiff
+      })
 
       // Assign positions
       data.teams.forEach((t, i) => { t.position = i + 1 })

--- a/app/tournaments/page.js
+++ b/app/tournaments/page.js
@@ -54,7 +54,7 @@ export default async function TournamentsPage() {
         <SectionHeading
           label="EVENTS"
           title="Tournaments"
-          description="One-day volleyball tournaments open to all teams. Multiple events per month."
+          description="One-day volleyball tournaments open to all teams. Pool play into Gold and Silver brackets."
         />
 
         {live.length > 0 && (

--- a/lib/server/leagues.js
+++ b/lib/server/leagues.js
@@ -174,6 +174,17 @@ export function getLeagueStandings(slug) {
         teamStats[team.id] = { id: team.id, name: team.name, setsWon: 0, setsLost: 0, pointDiff: 0, basePoints: 0, totalPoints: 0 }
       }
 
+      // Head-to-head point differential. h2h[a][b] is A's net points across
+      // every set A ever played against B. Positive means A "owns" B on points.
+      // Used as a tiebreaker BEFORE overall point diff — if Lincas and ESH
+      // finish on identical totalPoints, we look at the sets they actually
+      // played against each other, not season-wide margin-fluffing.
+      const h2h = {}
+      const bumpH2H = (a, b, delta) => {
+        if (!h2h[a]) h2h[a] = {}
+        h2h[a][b] = (h2h[a][b] || 0) + delta
+      }
+
       for (const week of season.weeks) {
         if (week.weekNumber === 1) continue
         const weekTeamSets = {}
@@ -183,6 +194,9 @@ export function getLeagueStandings(slug) {
             const diff = score.homeScore - score.awayScore
             if (!weekTeamSets[match.homeTeamId]) weekTeamSets[match.homeTeamId] = { sets: 0, tierNumber: match.tierNumber }
             if (!weekTeamSets[match.awayTeamId]) weekTeamSets[match.awayTeamId] = { sets: 0, tierNumber: match.tierNumber }
+            // Raw point delta per set, from home's perspective. Mirror for away.
+            bumpH2H(match.homeTeamId, match.awayTeamId, diff)
+            bumpH2H(match.awayTeamId, match.homeTeamId, -diff)
             if (homeWon) {
               weekTeamSets[match.homeTeamId].sets++
               if (teamStats[match.homeTeamId]) { teamStats[match.homeTeamId].setsWon++; teamStats[match.homeTeamId].pointDiff += diff }
@@ -203,8 +217,26 @@ export function getLeagueStandings(slug) {
         }
       }
 
+      // Tiebreaker cascade is league-specific.
+      //
+      // Sunday MENS plays 3 sets against each opponent every week, which gives
+      // a real head-to-head sample worth breaking ties on — a team shouldn't
+      // leapfrog a rival they actually lost to just by running up the score on
+      // weaker tiers.
+      //
+      // COED (Tuesday + Thursday REC) uses the original totalPoints → overall
+      // pointDiff rule — they play shorter series so h2h is noisier, and the
+      // league owner explicitly wants the legacy behaviour there.
+      const useHeadToHead = slug === 'sunday-mens'
       const standings = Object.values(teamStats)
-        .sort((a, b) => b.totalPoints - a.totalPoints || b.pointDiff - a.pointDiff)
+        .sort((a, b) => {
+          if (b.totalPoints !== a.totalPoints) return b.totalPoints - a.totalPoints
+          if (useHeadToHead) {
+            const h = (h2h[b.id]?.[a.id] ?? 0) - (h2h[a.id]?.[b.id] ?? 0)
+            if (h !== 0) return h
+          }
+          return b.pointDiff - a.pointDiff
+        })
         .map((t, i) => ({ ...t, rank: i + 1 }))
 
       const lastWeek = season.weeks[season.weeks.length - 1]

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,9 +54,15 @@ export function getSlotInfo(tierNumber, timeSlot) {
 
 /**
  * Returns division info for a given rank within a league.
- * COED (24 teams): Diamond 1-5, Platinum 6-10, Gold 11-15, Silver 16-20, Bronze 21-24
- * MENS (15 teams): Diamond 1-3, Platinum 4-6, Gold 7-9, Silver 10-12, Bronze 13-15
- * Pass leagueType='mens' for the 15-team grouping, defaults to 'coed'.
+ *
+ * MENS: split in half — top half Diamond, bottom half Platinum. A 12-team
+ * Sunday MENS season pays out Diamond 1-6, Platinum 7-12. We deliberately
+ * don't surface Gold/Silver/Bronze on MENS because there are only two payout
+ * tiers; forcing a 5-way split would invent divisions that don't exist.
+ *
+ * COED (24 teams): Diamond 1-5, Platinum 6-10, Gold 11-15, Silver 16-20, Bronze 21-24.
+ *
+ * Pass leagueType='mens' for the two-way MENS split; defaults to 'coed'.
  */
 export function getDivisionInfo(rank, totalTeams, leagueType = 'coed') {
   const divisions = [
@@ -67,12 +73,11 @@ export function getDivisionInfo(rank, totalTeams, leagueType = 'coed') {
     { name: 'Bronze', color: 'div-bronze', bgClass: 'division-bronze' },
   ]
 
-  // For MENS or small leagues (15 or fewer teams), groups of 3
-  if (leagueType === 'mens' || totalTeams <= 15) {
-    const groupSize = 3
-    const divisionIndex = Math.floor((rank - 1) / groupSize)
-    const clamped = Math.min(divisionIndex, divisions.length - 1)
-    return divisions[clamped]
+  // MENS: single cut down the middle. Odd totals give Diamond the extra seat
+  // (Math.ceil), matching how the prize pool splits in practice.
+  if (leagueType === 'mens') {
+    const half = Math.ceil(totalTeams / 2)
+    return rank <= half ? divisions[0] : divisions[1]
   }
 
   // COED structure (24 teams): 5-5-5-5-4

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -75,12 +75,20 @@ describe('getDivisionInfo()', () => {
   it('returns Bronze for last in COED', () => {
     expect(getDivisionInfo(24, 24, 'coed').name).toBe('Bronze')
   })
-  it('returns Diamond for rank 1-3 in MENS', () => {
-    expect(getDivisionInfo(1, 15, 'mens').name).toBe('Diamond')
-    expect(getDivisionInfo(3, 15, 'mens').name).toBe('Diamond')
+  it('splits MENS evenly into Diamond and Platinum (12 teams)', () => {
+    expect(getDivisionInfo(1, 12, 'mens').name).toBe('Diamond')
+    expect(getDivisionInfo(6, 12, 'mens').name).toBe('Diamond')
+    expect(getDivisionInfo(7, 12, 'mens').name).toBe('Platinum')
+    expect(getDivisionInfo(12, 12, 'mens').name).toBe('Platinum')
   })
-  it('returns Platinum for rank 4-6 in MENS', () => {
-    expect(getDivisionInfo(4, 15, 'mens').name).toBe('Platinum')
+  it('gives MENS Diamond the extra seat on odd totals (15 teams)', () => {
+    // 15 teams → ceil(15/2) = 8 → Diamond 1-8, Platinum 9-15
+    expect(getDivisionInfo(8, 15, 'mens').name).toBe('Diamond')
+    expect(getDivisionInfo(9, 15, 'mens').name).toBe('Platinum')
+  })
+  it('never surfaces Gold/Silver/Bronze on MENS', () => {
+    const names = Array.from({ length: 12 }, (_, i) => getDivisionInfo(i + 1, 12, 'mens').name)
+    expect(names.every(n => n === 'Diamond' || n === 'Platinum')).toBe(true)
   })
 })
 


### PR DESCRIPTION
Three related fixes reported while using the admin tooling:

1. Tournament scheduled time saved in the wrong timezone. <input type="datetime-local"> returns a bare "YYYY-MM-DDTHH:mm" with no TZ designator. Vercel's UTC runtime parsed it as UTC, shifting stored times by the admin's TZ offset (EST admin typed 10:00 → DB stored 10:00 UTC = 6:00 EST). Added a localInputToISO() helper on both admin tournament forms so the browser parses the value as local time and sends a proper UTC ISO string — the server can't re-interpret it.

2. Sunday MENS standings and weekly tier finish order ignored head-to-head. Two-level sort (totalPoints → pointDiff) let a team leapfrog a rival they actually lost to by running up the score on weaker tiers. Added a pairwise h2h point-diff map to both lib/server/leagues.js (season standings) and app/api/admin/tier-movement/route.js (weekly placements). Gated to slug === 'sunday-mens' so COED leagues keep the legacy rule — owner's call.

3. MENS division labels still tried to produce 5 groups of 3. Real league only has two payout tiers, so getDivisionInfo now splits MENS down the middle (Diamond = top half, Platinum = bottom half). 12 teams → 6/6. COED untouched.