### PR TITLE
feat(tournament): canonical bracket schedule, admin UX polish, ref as…

### DIFF
--- a/app/admin/tournaments/[slug]/bracket/page.js
+++ b/app/admin/tournaments/[slug]/bracket/page.js
@@ -5,7 +5,41 @@ import Link from 'next/link'
 import { ArrowLeft, Loader2, RefreshCw, Trophy, Medal } from 'lucide-react'
 import AuthGate from '@/components/admin/AuthGate'
 import ScoreEntry from '@/components/tournament/ScoreEntry'
+import BracketMatchMeta from '@/components/tournament/BracketMatchMeta'
 import { BRACKET_ROUND } from '@/lib/tournament/constants'
+import { cleanTeamName } from '@/lib/tournament/displayName'
+
+// Small identity strip at the top of each match card. Admins kept asking
+// "which match am I editing?" because court/ref controls floated above a
+// collapsed score card with no shared framing — now the teams + status sit
+// at the very top so the whole block reads as one match.
+function MatchIdentity({ match }) {
+  const home = cleanTeamName(match.homeTeam?.name) || match.homeSeedLabel || 'TBD'
+  const away = cleanTeamName(match.awayTeam?.name) || match.awaySeedLabel || 'TBD'
+  const statusTone =
+    match.status === 'live' ? 'text-status-live'
+    : match.status === 'completed' ? 'text-status-success'
+    : 'text-titos-gray-500'
+  const statusLabel =
+    match.status === 'live' ? 'Live'
+    : match.status === 'completed' ? 'Final'
+    : 'Scheduled'
+  return (
+    <div className="px-3 py-2 bg-titos-elevated/40 border-b border-titos-border/40 flex items-center gap-3 flex-wrap">
+      <span className={`inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider ${statusTone}`}>
+        {match.status === 'live' && (
+          <span className="w-1.5 h-1.5 rounded-full bg-status-live animate-pulse" aria-hidden="true" />
+        )}
+        {statusLabel}
+      </span>
+      <span className="text-sm font-semibold text-titos-white truncate flex-1 min-w-0">
+        {home}
+        <span className="text-titos-gray-600 mx-1.5">vs</span>
+        {away}
+      </span>
+    </div>
+  )
+}
 
 const ROUND_LABELS = {
   [BRACKET_ROUND.QUARTERFINAL]: 'Quarterfinals',
@@ -68,14 +102,35 @@ function Inner({ slug }) {
                       <h3 className="text-xs font-bold uppercase tracking-wider text-titos-gray-500 mb-2">
                         {ROUND_LABELS[Number(round)] || `Round ${round}`}
                       </h3>
-                      <div className="space-y-2">
+                      {/* 2-up at md+ so 4 QFs become 2 rows instead of 4.
+                          SFs + Finals also pair up nicely when both divisions
+                          are generated. Cuts page scroll roughly in half. */}
+                      <div className="grid gap-3 md:grid-cols-2">
                         {matches.map(m => (
-                          <ScoreEntry
+                          // Unified match card: identity strip → court/ref
+                          // controls → score entry. Everything inside reads
+                          // as belonging to ONE match, so there's no chance
+                          // of editing the wrong row's court/ref.
+                          <div
                             key={m.id}
-                            match={m}
-                            saveUrl={`/api/admin/tournaments/${slug}/bracket-matches/${m.id}/scores`}
-                            onSaved={load}
-                          />
+                            className="card-flat rounded-lg overflow-hidden border border-titos-border/40"
+                            data-status={m.status}
+                          >
+                            <MatchIdentity match={m} />
+                            <BracketMatchMeta
+                              match={m}
+                              slug={slug}
+                              tournamentTeams={tournament.tournamentTeams || []}
+                              onSaved={load}
+                              flush
+                            />
+                            <ScoreEntry
+                              match={m}
+                              saveUrl={`/api/admin/tournaments/${slug}/bracket-matches/${m.id}/scores`}
+                              onSaved={load}
+                              flush
+                            />
+                          </div>
                         ))}
                       </div>
                     </div>

--- a/app/admin/tournaments/[slug]/page.js
+++ b/app/admin/tournaments/[slug]/page.js
@@ -566,6 +566,18 @@ function PoolsPanel({ tournament, onChange }) {
     else onChange()
     setBusy('')
   }
+  const resetScores = async () => {
+    if (!confirm('Reset ALL pool scores? Matches, pairings, and seeds stay — only scores + winners are wiped. Useful for re-running pool play in testing.')) return
+    setBusy('reset'); setErr(''); setInfo('')
+    const res = await adminPost(`/api/admin/tournaments/${tournament.slug}/reset-scores`, {})
+    const data = await res.json().catch(() => ({}))
+    if (!res.ok) { setErr(data.error || 'Failed') }
+    else {
+      setInfo(`Reset ${data.reset ?? 0} match${data.reset === 1 ? '' : 'es'} · cleared ${data.scoresDeleted ?? 0} set score${data.scoresDeleted === 1 ? '' : 's'}`)
+      onChange()
+    }
+    setBusy('')
+  }
 
   const assignTeam = async (teamId, poolId) => {
     const res = await adminPatch(`/api/admin/tournaments/${tournament.slug}/pool-teams`, { teamId, poolId })
@@ -607,6 +619,17 @@ function PoolsPanel({ tournament, onChange }) {
             <button onClick={generateSchedule} disabled={busy === 'schedule'} className="btn-primary text-xs py-2">
               {busy === 'schedule' ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Check className="w-3.5 h-3.5" />}
               Generate Schedule
+            </button>
+          )}
+          {poolsHaveMatches && (
+            <button
+              onClick={resetScores}
+              disabled={busy === 'reset'}
+              title="Wipe every pool-match score and flip all matches back to 'scheduled'. Keeps pairings, courts, and seeds intact — perfect for re-running pool play while testing."
+              className="inline-flex items-center gap-1.5 text-xs py-2 px-3 text-titos-gray-300 border border-titos-border rounded-lg hover:border-titos-gold/40 hover:text-titos-white transition-colors"
+            >
+              {busy === 'reset' ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <RefreshCw className="w-3.5 h-3.5" />}
+              Reset Scores
             </button>
           )}
           {poolsHaveMatches && (
@@ -685,17 +708,27 @@ function PoolsPanel({ tournament, onChange }) {
 function BracketPanel({ tournament, onChange }) {
   const [busy, setBusy] = useState('')
   const [err, setErr] = useState('')
+  const [pending, setPending] = useState([])
 
   const generateBrackets = async () => {
-    setBusy('generate'); setErr('')
+    setBusy('generate'); setErr(''); setPending([])
     const res = await adminPost(`/api/admin/tournaments/${tournament.slug}/brackets`, {})
-    if (!res.ok) { const d = await res.json(); setErr(d.error || 'Failed') }
+    if (!res.ok) {
+      const d = await res.json().catch(() => ({}))
+      setErr(d.error || 'Failed')
+      // Surface the specific pool matches still blocking bracket generation,
+      // so the admin sees exactly what to fix instead of a generic error.
+      if (Array.isArray(d.pending)) setPending(d.pending)
+    }
     else onChange()
     setBusy('')
   }
   const deleteBrackets = async () => {
-    if (!confirm('Delete all brackets?')) return
-    setBusy('delete'); setErr('')
+    // Explicit: this wipes every bracket match AND any scores already entered
+    // on them. Pool play is untouched. We prompt plainly so nobody trips the
+    // button expecting a no-op.
+    if (!confirm('Delete all brackets? This also wipes any bracket match scores. Pool play is untouched.')) return
+    setBusy('delete'); setErr(''); setPending([])
     const res = await adminDelete(`/api/admin/tournaments/${tournament.slug}/brackets`)
     if (!res.ok) { const d = await res.json(); setErr(d.error || 'Failed') }
     else onChange()
@@ -726,6 +759,18 @@ function BracketPanel({ tournament, onChange }) {
       }
     >
       {err && <p className="text-status-live text-sm mb-3">{err}</p>}
+      {pending.length > 0 && (
+        <div className="mb-3 p-3 rounded-lg border border-status-live/30 bg-status-live/5">
+          <p className="text-titos-gray-300 text-xs mb-2">Pool matches still pending:</p>
+          <ul className="space-y-1">
+            {pending.map(m => (
+              <li key={m.id} className="text-titos-white text-sm">
+                <span className="text-titos-gray-500">Pool {m.pool} · {m.status}</span> — {m.label}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       {tournament.brackets.length === 0 ? (
         <p className="text-titos-gray-500 text-sm">
           Brackets appear once all pool matches are FINAL. Click Generate Brackets to seed Gold + Silver.

--- a/app/api/admin/tournaments/[slug]/bracket-matches/[matchId]/route.js
+++ b/app/api/admin/tournaments/[slug]/bracket-matches/[matchId]/route.js
@@ -1,0 +1,91 @@
+import prisma from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { checkAdminPassword, unauthorized } from '@/lib/server/adminAuth'
+import { revalidateTournament } from '@/lib/server/tournaments'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * PATCH — update bracket match metadata (court + ref).
+ *
+ * Separate from the scores endpoint because:
+ *   - Scores are high-frequency during live play; metadata is low-frequency
+ *     setup. Splitting the routes means saving a court number doesn't have
+ *     to walk the computeMatchStatus + advanceBracketWinner path.
+ *   - Court / ref are valid to set BEFORE any scores exist.
+ *
+ * Accepts any subset of { courtNumber, refTeamId } — omit a field to leave
+ * it unchanged; pass `null` to clear it.
+ */
+export async function PATCH(request, { params }) {
+  if (!checkAdminPassword(request)) return unauthorized()
+  const { slug, matchId } = await params
+  try {
+    const body = await request.json()
+
+    const match = await prisma.tournamentMatch.findUnique({
+      where: { id: matchId },
+      select: { id: true, bracketId: true, bracket: { select: { tournamentId: true } } },
+    })
+    if (!match) return NextResponse.json({ error: 'Match not found' }, { status: 404 })
+    if (!match.bracketId) {
+      return NextResponse.json({ error: 'Not a bracket match' }, { status: 400 })
+    }
+
+    const data = {}
+
+    if (Object.prototype.hasOwnProperty.call(body, 'courtNumber')) {
+      const raw = body.courtNumber
+      if (raw === null || raw === '') {
+        data.courtNumber = null
+      } else {
+        const n = Number(raw)
+        if (!Number.isFinite(n) || n < 1 || n > 99) {
+          return NextResponse.json({ error: 'courtNumber must be 1–99 or null' }, { status: 400 })
+        }
+        data.courtNumber = Math.round(n)
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(body, 'refTeamId')) {
+      const raw = body.refTeamId
+      if (raw === null || raw === '') {
+        data.refTeamId = null
+      } else if (typeof raw !== 'string') {
+        return NextResponse.json({ error: 'refTeamId must be a team id or null' }, { status: 400 })
+      } else {
+        // Validate the team belongs to this tournament — otherwise admins
+        // could accidentally point at a team from another event.
+        const team = await prisma.tournamentTeam.findUnique({
+          where: { id: raw },
+          select: { id: true, tournamentId: true },
+        })
+        if (!team || team.tournamentId !== match.bracket.tournamentId) {
+          return NextResponse.json({ error: 'Ref team is not in this tournament' }, { status: 400 })
+        }
+        data.refTeamId = raw
+      }
+    }
+
+    if (Object.keys(data).length === 0) {
+      return NextResponse.json({ error: 'Nothing to update' }, { status: 400 })
+    }
+
+    const updated = await prisma.tournamentMatch.update({
+      where: { id: matchId },
+      data,
+      select: {
+        id: true,
+        courtNumber: true,
+        refTeamId: true,
+        refTeam: { select: { id: true, name: true } },
+      },
+    })
+
+    revalidateTournament(slug)
+    return NextResponse.json(updated)
+  } catch (error) {
+    console.error('Update bracket match metadata error:', error)
+    return NextResponse.json({ error: 'Failed to update match' }, { status: 500 })
+  }
+}

--- a/app/api/admin/tournaments/[slug]/bracket-matches/[matchId]/scores/route.js
+++ b/app/api/admin/tournaments/[slug]/bracket-matches/[matchId]/scores/route.js
@@ -4,6 +4,7 @@ import { checkAdminPassword, unauthorized } from '@/lib/server/adminAuth'
 import { revalidateTournament } from '@/lib/server/tournaments'
 import { computeMatchStatus } from '@/lib/tournament/computeMatchStatus'
 import { advanceBracketWinner } from '@/lib/tournament/advanceBracketWinner'
+import { findNextOnSameCourt } from '@/lib/tournament/canonicalBracketSchedule'
 import { MATCH_STATUS } from '@/lib/tournament/constants'
 
 export const dynamic = 'force-dynamic'
@@ -64,5 +65,98 @@ export async function PATCH(request, { params }) {
   } catch (error) {
     console.error('Save bracket match scores error:', error)
     return NextResponse.json({ error: 'Failed to save scores' }, { status: 500 })
+  }
+}
+
+/**
+ * DELETE — wipe all set scores for a bracket match and reset it to
+ * SCHEDULED. Best-effort "undo" of the downstream effects too:
+ *
+ *   • If this match had a winner that advanced into next.homeTeamId or
+ *     next.awayTeamId, null that slot out (only if downstream hasn't
+ *     started scoring — we don't want to destroy a later match's state).
+ *   • If this match's loser had been stamped as ref on the next match on
+ *     the same court, clear that ref so it doesn't stick around stale.
+ *
+ * Used by the admin "Clear scores" button to genuinely remove a match
+ * result (not just set everything to 0–0, which would still count).
+ */
+export async function DELETE(request, { params }) {
+  if (!checkAdminPassword(request)) return unauthorized()
+  const { slug, matchId } = await params
+  try {
+    const match = await prisma.tournamentMatch.findUnique({
+      where: { id: matchId },
+      select: {
+        id: true,
+        winnerId: true,
+        homeTeamId: true,
+        awayTeamId: true,
+        nextMatchId: true,
+        bracketId: true,
+        courtNumber: true,
+        scheduledTime: true,
+      },
+    })
+    if (!match) return NextResponse.json({ error: 'Match not found' }, { status: 404 })
+    if (!match.bracketId) {
+      return NextResponse.json({ error: 'Not a bracket match' }, { status: 400 })
+    }
+
+    const loserId = match.winnerId
+      ? (match.winnerId === match.homeTeamId ? match.awayTeamId : match.homeTeamId)
+      : null
+
+    await prisma.$transaction(async (tx) => {
+      // 1) Delete the set scores.
+      await tx.tournamentSetScore.deleteMany({ where: { matchId } })
+
+      // 2) Reset the match status + winner.
+      await tx.tournamentMatch.update({
+        where: { id: matchId },
+        data: { status: MATCH_STATUS.SCHEDULED, winnerId: null },
+      })
+
+      // 3) Un-advance winner into downstream slot, if safe.
+      if (match.nextMatchId && match.winnerId) {
+        const next = await tx.tournamentMatch.findUnique({
+          where: { id: match.nextMatchId },
+          select: {
+            id: true,
+            homeTeamId: true,
+            awayTeamId: true,
+            scores: { select: { id: true } },
+          },
+        })
+        // Only safe if the downstream match has NOT yet had scores entered —
+        // otherwise we'd rip a team out from under an in-progress result.
+        if (next && next.scores.length === 0) {
+          const patch = {}
+          if (next.homeTeamId === match.winnerId) patch.homeTeamId = null
+          if (next.awayTeamId === match.winnerId) patch.awayTeamId = null
+          if (Object.keys(patch).length > 0) {
+            await tx.tournamentMatch.update({ where: { id: next.id }, data: patch })
+          }
+        }
+      }
+
+      // 4) Un-ref: if our loser was auto-assigned as ref on the next match
+      //    on this court, clear that ref so the admin can reassign.
+      if (loserId) {
+        const nextOnCourt = await findNextOnSameCourt(tx, match)
+        if (nextOnCourt && nextOnCourt.refTeamId === loserId) {
+          await tx.tournamentMatch.update({
+            where: { id: nextOnCourt.id },
+            data: { refTeamId: null },
+          })
+        }
+      }
+    })
+
+    revalidateTournament(slug)
+    return NextResponse.json({ cleared: true })
+  } catch (error) {
+    console.error('Clear bracket match scores error:', error)
+    return NextResponse.json({ error: 'Failed to clear scores' }, { status: 500 })
   }
 }

--- a/app/api/admin/tournaments/[slug]/brackets/route.js
+++ b/app/api/admin/tournaments/[slug]/brackets/route.js
@@ -2,9 +2,14 @@ import prisma from '@/lib/prisma'
 import { NextResponse } from 'next/server'
 import { checkAdminPassword, unauthorized } from '@/lib/server/adminAuth'
 import { revalidateTournament } from '@/lib/server/tournaments'
-import { canStartBrackets } from '@/lib/tournament/canStartBrackets'
+import { diagnoseBracketReadiness } from '@/lib/tournament/canStartBrackets'
 import { generateBracketSeeding } from '@/lib/tournament/generateBracketSeeding'
 import { computeStandingsFromMatches } from '@/lib/tournament/calculateStandings'
+import {
+  courtFor,
+  scheduledTimeFor,
+  initialQfRef,
+} from '@/lib/tournament/canonicalBracketSchedule'
 import {
   DIVISIONS,
   MATCH_STATUS, BRACKET_ROUND,
@@ -51,10 +56,12 @@ export async function POST(request, { params }) {
       )
     }
 
-    const ready = await canStartBrackets(t.id, prisma)
-    if (!ready) {
+    const readiness = await diagnoseBracketReadiness(t.id, prisma)
+    if (!readiness.ok) {
+      // Surface the specific pending matches so the admin knows exactly which
+      // pool matches still need scores instead of a generic "not ready" error.
       return NextResponse.json(
-        { error: 'Not all pool matches are complete yet.' },
+        { error: readiness.reason, pending: readiness.pending ?? [] },
         { status: 400 },
       )
     }
@@ -67,6 +74,7 @@ export async function POST(request, { params }) {
     })
 
     const createdBrackets = []
+    const kickoff = t.date ? new Date(t.date) : null
 
     for (const division of DIVISIONS) {
       const qfSeeds = generateBracketSeeding(poolsForSeeding, division)
@@ -93,12 +101,18 @@ export async function POST(request, { params }) {
             homeSeedLabel: 'SF1 Winner',
             awaySeedLabel: 'SF2 Winner',
             status: MATCH_STATUS.SCHEDULED,
+            courtNumber: courtFor({ division, bracketRound: BRACKET_ROUND.FINAL, bracketPosition: 0 }),
+            scheduledTime: scheduledTimeFor({ kickoff, bracketRound: BRACKET_ROUND.FINAL, bracketPosition: 0 }),
           },
         })
         finalId = finalMatch.id
       }
 
       // SF shells — each SF feeds `finalId` (when present).
+      // Per PDF: same-court QFs feed the same SF. QF pos 0 & pos 2 (both
+      // on the lower court) feed SF pos 0; QF pos 1 & pos 3 (both on the
+      // upper court) feed SF pos 1. So SF s is fed by QFs at positions
+      // `s` and `s + 2` — labels below reflect that.
       const sfIds = []
       for (let s = 0; s < sfCount; s++) {
         const sf = await prisma.tournamentMatch.create({
@@ -106,20 +120,24 @@ export async function POST(request, { params }) {
             bracketId: bracket.id,
             bracketRound: BRACKET_ROUND.SEMIFINAL,
             bracketPosition: s,
-            homeSeedLabel: `QF${s * 2 + 1} Winner`,
-            awaySeedLabel: `QF${s * 2 + 2} Winner`,
+            homeSeedLabel: `QF${s + 1} Winner`,
+            awaySeedLabel: `QF${s + 3} Winner`,
             nextMatchId: finalId, // SF winners advance to the single Final
             status: MATCH_STATUS.SCHEDULED,
+            courtNumber: courtFor({ division, bracketRound: BRACKET_ROUND.SEMIFINAL, bracketPosition: s }),
+            scheduledTime: scheduledTimeFor({ kickoff, bracketRound: BRACKET_ROUND.SEMIFINAL, bracketPosition: s }),
           },
         })
         sfIds.push(sf.id)
       }
 
-      // QF matches — each QF feeds sfIds[floor(i/2)].
+      // QF matches — same-court wiring: QF at position i feeds sfIds[i % 2]
+      // so (pos 0, pos 2) both feed SF0 and (pos 1, pos 3) both feed SF1.
+      const createdQfs = []
       for (let i = 0; i < qfCount; i++) {
         const qf = qfSeeds[i]
-        const sfIndex = Math.floor(i / 2)
-        await prisma.tournamentMatch.create({
+        const sfIndex = i % sfCount
+        const created = await prisma.tournamentMatch.create({
           data: {
             bracketId: bracket.id,
             bracketRound: BRACKET_ROUND.QUARTERFINAL,
@@ -130,8 +148,25 @@ export async function POST(request, { params }) {
             awaySeedLabel: qf.teamBSeedLabel ?? null,
             nextMatchId: sfIds[sfIndex] ?? null,
             status: MATCH_STATUS.SCHEDULED,
+            courtNumber: courtFor({ division, bracketRound: BRACKET_ROUND.QUARTERFINAL, bracketPosition: i }),
+            scheduledTime: scheduledTimeFor({ kickoff, bracketRound: BRACKET_ROUND.QUARTERFINAL, bracketPosition: i }),
           },
         })
+        createdQfs.push(created)
+      }
+
+      // Pass 2: assign the generation-time refs for the two 1:00 PM QFs.
+      // Each gets its ref from the HOME team of the QF playing the same court
+      // at 1:45 PM (guaranteed idle, known at this point). Later slots get
+      // their refs via advanceBracketWinner once earlier matches finalize.
+      for (const qf of createdQfs) {
+        const refTeamId = initialQfRef(qf, createdQfs)
+        if (refTeamId) {
+          await prisma.tournamentMatch.update({
+            where: { id: qf.id },
+            data: { refTeamId },
+          })
+        }
       }
 
       createdBrackets.push({ id: bracket.id, division, qf: qfCount, sf: sfCount, final: needsFinal ? 1 : 0 })
@@ -146,7 +181,17 @@ export async function POST(request, { params }) {
 }
 
 /**
- * DELETE — tear down all bracket matches and brackets (only if no scores saved).
+ * DELETE — tear down ALL bracket matches and brackets, unconditionally.
+ *
+ * This is an explicit admin "wipe the bracket" action (distinct from the
+ * per-match "clear scores" button). It cascades:
+ *   1) Wipe every TournamentSetScore attached to a bracket match.
+ *   2) Null every nextMatchId pointer so the self-FK chain is safe to drop.
+ *   3) Delete the bracket matches, then the brackets themselves.
+ *
+ * Scores are intentionally NOT a guard here: once pool play advances the
+ * wrong teams or the schedule itself is wrong, the only recovery is to
+ * regenerate — which requires this to actually succeed.
  */
 export async function DELETE(request, { params }) {
   if (!checkAdminPassword(request)) return unauthorized()
@@ -160,27 +205,29 @@ export async function DELETE(request, { params }) {
 
     const matches = await prisma.tournamentMatch.findMany({
       where: { bracket: { tournamentId: t.id } },
-      select: { id: true, scores: { select: { id: true } } },
+      select: { id: true },
     })
-    const hasScores = matches.some(m => m.scores.length > 0)
-    if (hasScores) {
-      return NextResponse.json(
-        { error: 'Cannot delete — bracket matches have scores entered.' },
-        { status: 409 },
-      )
-    }
-
     const ids = matches.map(m => m.id)
+
     if (ids.length) {
-      // Null nextMatchId chain first to avoid FK constraints on delete
-      await prisma.tournamentMatch.updateMany({ where: { id: { in: ids } }, data: { nextMatchId: null } })
-      await prisma.tournamentSetScore.deleteMany({ where: { matchId: { in: ids } } })
-      await prisma.tournamentMatch.deleteMany({ where: { id: { in: ids } } })
+      // Transaction so a partial teardown never leaves dangling FK refs —
+      // either the whole bracket is gone or nothing changed.
+      await prisma.$transaction([
+        prisma.tournamentSetScore.deleteMany({ where: { matchId: { in: ids } } }),
+        prisma.tournamentMatch.updateMany({
+          where: { id: { in: ids } },
+          data: { nextMatchId: null },
+        }),
+        prisma.tournamentMatch.deleteMany({ where: { id: { in: ids } } }),
+        prisma.tournamentBracket.deleteMany({ where: { tournamentId: t.id } }),
+      ])
+    } else {
+      // No matches — just drop any orphan bracket rows.
+      await prisma.tournamentBracket.deleteMany({ where: { tournamentId: t.id } })
     }
-    await prisma.tournamentBracket.deleteMany({ where: { tournamentId: t.id } })
 
     revalidateTournament(slug)
-    return NextResponse.json({ success: true })
+    return NextResponse.json({ success: true, deletedMatches: ids.length })
   } catch (error) {
     console.error('Delete brackets error:', error)
     return NextResponse.json({ error: 'Failed to delete brackets' }, { status: 500 })

--- a/app/api/admin/tournaments/[slug]/matches/[matchId]/scores/route.js
+++ b/app/api/admin/tournaments/[slug]/matches/[matchId]/scores/route.js
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { checkAdminPassword, unauthorized } from '@/lib/server/adminAuth'
 import { revalidateTournament } from '@/lib/server/tournaments'
 import { computeMatchStatus } from '@/lib/tournament/computeMatchStatus'
+import { MATCH_STATUS } from '@/lib/tournament/constants'
 
 export const dynamic = 'force-dynamic'
 
@@ -61,5 +62,36 @@ export async function PATCH(request, { params }) {
   } catch (error) {
     console.error('Save match scores error:', error)
     return NextResponse.json({ error: 'Failed to save scores' }, { status: 500 })
+  }
+}
+
+/**
+ * DELETE — wipe all set scores for a pool match and reset its status to
+ * SCHEDULED (winnerId cleared). Used by the admin "Clear scores" button
+ * when a result needs to be redone from scratch.
+ */
+export async function DELETE(request, { params }) {
+  if (!checkAdminPassword(request)) return unauthorized()
+  const { slug, matchId } = await params
+  try {
+    const match = await prisma.tournamentMatch.findUnique({
+      where: { id: matchId },
+      select: { id: true, poolId: true },
+    })
+    if (!match) return NextResponse.json({ error: 'Match not found' }, { status: 404 })
+
+    await prisma.$transaction(async (tx) => {
+      await tx.tournamentSetScore.deleteMany({ where: { matchId } })
+      await tx.tournamentMatch.update({
+        where: { id: matchId },
+        data: { status: MATCH_STATUS.SCHEDULED, winnerId: null },
+      })
+    })
+
+    revalidateTournament(slug)
+    return NextResponse.json({ cleared: true })
+  } catch (error) {
+    console.error('Clear match scores error:', error)
+    return NextResponse.json({ error: 'Failed to clear scores' }, { status: 500 })
   }
 }

--- a/app/api/admin/tournaments/[slug]/reset-scores/route.js
+++ b/app/api/admin/tournaments/[slug]/reset-scores/route.js
@@ -1,0 +1,74 @@
+import prisma from '@/lib/prisma'
+import { NextResponse } from 'next/server'
+import { checkAdminPassword, unauthorized } from '@/lib/server/adminAuth'
+import { revalidateTournament } from '@/lib/server/tournaments'
+import { MATCH_STATUS } from '@/lib/tournament/constants'
+
+export const dynamic = 'force-dynamic'
+
+/**
+ * POST — wipe all pool-stage scores so the tournament can be re-played from
+ * scratch for testing. Unlike DELETE /schedule, this keeps match pairings,
+ * court assignments, seeds, and scheduledTime intact — just resets each match
+ * back to `scheduled`, nulls out the winner, and deletes every set score row.
+ *
+ * Refuses if brackets exist. Bracket seeding is derived from pool standings,
+ * so mass-resetting pool scores while brackets are live would leave the
+ * bracket stale. Delete brackets first via the existing admin button, then
+ * run this, then replay scores.
+ *
+ * Safe to run multiple times. Idempotent.
+ */
+export async function POST(request, { params }) {
+  if (!checkAdminPassword(request)) return unauthorized()
+  const { slug } = await params
+  try {
+    const t = await prisma.tournament.findUnique({
+      where: { slug },
+      select: {
+        id: true,
+        brackets: { select: { id: true } },
+      },
+    })
+    if (!t) return NextResponse.json({ error: 'Tournament not found' }, { status: 404 })
+
+    if (t.brackets.length > 0) {
+      return NextResponse.json(
+        { error: 'Delete brackets before resetting pool scores — bracket seeding is derived from pool standings.' },
+        { status: 409 },
+      )
+    }
+
+    // Find every pool match for this tournament. We only touch pool matches
+    // (match.poolId is set) — bracket matches live under match.bracketId and
+    // should not be reset here.
+    const matches = await prisma.tournamentMatch.findMany({
+      where: { pool: { tournamentId: t.id } },
+      select: { id: true },
+    })
+    const ids = matches.map(m => m.id)
+
+    if (ids.length === 0) {
+      return NextResponse.json({ reset: 0, scoresDeleted: 0 })
+    }
+
+    // One transaction: drop all set scores, then flip every match back to
+    // scheduled with no winner. Both writes succeed or both roll back.
+    const [deleted, updated] = await prisma.$transaction([
+      prisma.tournamentSetScore.deleteMany({ where: { matchId: { in: ids } } }),
+      prisma.tournamentMatch.updateMany({
+        where: { id: { in: ids } },
+        data: { status: MATCH_STATUS.SCHEDULED, winnerId: null },
+      }),
+    ])
+
+    revalidateTournament(slug)
+    return NextResponse.json({
+      reset: updated.count,
+      scoresDeleted: deleted.count,
+    })
+  } catch (error) {
+    console.error('Reset pool scores error:', error)
+    return NextResponse.json({ error: 'Failed to reset scores' }, { status: 500 })
+  }
+}

--- a/app/api/tournaments/[slug]/route.js
+++ b/app/api/tournaments/[slug]/route.js
@@ -16,6 +16,7 @@ export async function GET(request, { params }) {
             include: {
               homeTeam: { select: { id: true, name: true } },
               awayTeam: { select: { id: true, name: true } },
+              refTeam: { select: { id: true, name: true } },
               scores: { orderBy: { setNumber: 'asc' } },
             },
           },
@@ -27,6 +28,7 @@ export async function GET(request, { params }) {
             include: {
               homeTeam: { select: { id: true, name: true } },
               awayTeam: { select: { id: true, name: true } },
+              refTeam: { select: { id: true, name: true } },
               scores: { orderBy: { setNumber: 'asc' } },
             },
             orderBy: [{ bracketRound: 'asc' }, { bracketPosition: 'asc' }],

--- a/app/tournaments/[slug]/TournamentHubClient.js
+++ b/app/tournaments/[slug]/TournamentHubClient.js
@@ -7,15 +7,19 @@
 // pure function that powers the server render for consistency.
 
 import { useMemo, useState } from 'react'
+import { Trophy, Medal, Crown, MapPin, UserCheck } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import LivePoller from '@/components/tournament/LivePoller'
 import LiveIndicator from '@/components/tournament/LiveIndicator'
 import LiveMatchCard from '@/components/tournament/LiveMatchCard'
-import MatchCard from '@/components/tournament/MatchCard'
+import PoolMatchesList from '@/components/tournament/PoolMatchesList'
 import StandingsTable from '@/components/tournament/StandingsTable'
 import TeamPicker from '@/components/tournament/TeamPicker'
 import TeamSchedule from '@/components/tournament/TeamSchedule'
+import BracketTree from '@/components/tournament/BracketTree'
 import { computeStandingsFromMatches } from '@/lib/tournament/calculateStandings'
+import { cleanTeamName } from '@/lib/tournament/displayName'
+import { DIVISION_GOLD, DIVISION_SILVER, BRACKET_ROUND, MATCH_STATUS } from '@/lib/tournament/constants'
 
 function findLiveMatches(tournament) {
   const live = []
@@ -119,6 +123,14 @@ function HubBody({ slug, tournament }) {
         </section>
       )}
 
+      {/* Playoff brackets — once generated they're the main story, so they
+          sit ABOVE pool play. Pool standings still render below for context
+          (how did we get here). Each division is its own collapsible card so
+          players scan straight to their draw. */}
+      {(tournament?.brackets || []).length > 0 && (
+        <BracketsSection brackets={tournament.brackets} />
+      )}
+
       {/* Pool play */}
       {poolsWithStandings.length > 0 && (
         <section className="mb-10" aria-labelledby="pools-heading">
@@ -171,18 +183,11 @@ function HubBody({ slug, tournament }) {
                   standings={pool.standings}
                   selectedTeamId={selectedTeamId || null}
                 />
-                {pool.matches?.length > 0 && (
-                  <div className="space-y-1.5">
-                    {pool.matches.map(m => (
-                      <MatchCard
-                        key={m.id}
-                        match={m}
-                        variant="pool"
-                        poolTeams={pool.teams}
-                      />
-                    ))}
-                  </div>
-                )}
+                {/* Collapsible per-round breakdown. Live / next round is
+                    expanded automatically; past rounds collapse with a
+                    compact summary so users aren't scrolling through a wall
+                    of final scores. */}
+                <PoolMatchesList matches={pool.matches} poolTeams={pool.teams} />
               </div>
             ))}
           </div>
@@ -193,6 +198,256 @@ function HubBody({ slug, tournament }) {
         <p className="text-titos-gray-400 text-center py-8">Pools will appear here once the tournament is configured.</p>
       )}
     </>
+  )
+}
+
+/**
+ * Bracket status helpers — derive the "story" of a bracket so the header
+ * can show either the crowned Champion or the Next-up match instead of
+ * the generic "7 matches" count.
+ */
+function findChampion(bracket) {
+  const final = (bracket?.matches || []).find(
+    m => m.bracketRound === BRACKET_ROUND.FINAL,
+  )
+  if (!final || final.status !== MATCH_STATUS.FINAL || !final.winnerId) return null
+  if (final.winnerId === final.homeTeamId) return final.homeTeam
+  if (final.winnerId === final.awayTeamId) return final.awayTeam
+  return null
+}
+
+function findNextUp(bracket) {
+  // Returns the *group* of matches currently deserving spotlight, not just
+  // one. The playoff schedule runs two QFs concurrently (Gold: Courts 1&2,
+  // Silver: Courts 3&4) and two SFs concurrently, so collapsing to a single
+  // card hides half the action. Priority:
+  //   1. If any match is LIVE, return ALL live matches.
+  //   2. Otherwise find the earliest scheduledTime among pending matches
+  //      and return every pending match at that same timestamp (same slot).
+  //   3. Fallback: if nothing has a scheduledTime, return the single
+  //      earliest-by-(round, position) pending match so the callout still
+  //      shows something.
+  const pending = (bracket?.matches || []).filter(
+    (m) => m.status !== MATCH_STATUS.FINAL,
+  )
+  if (pending.length === 0) return []
+
+  const lives = pending.filter((m) => m.status === MATCH_STATUS.LIVE)
+  if (lives.length > 0) {
+    return lives
+      .slice()
+      .sort(
+        (a, b) =>
+          (a.courtNumber ?? 99) - (b.courtNumber ?? 99) ||
+          (a.bracketPosition ?? 0) - (b.bracketPosition ?? 0),
+      )
+  }
+
+  const withTime = pending.filter((m) => m.scheduledTime)
+  if (withTime.length > 0) {
+    const earliest = Math.min(
+      ...withTime.map((m) => new Date(m.scheduledTime).getTime()),
+    )
+    return withTime
+      .filter((m) => new Date(m.scheduledTime).getTime() === earliest)
+      .sort(
+        (a, b) =>
+          (a.courtNumber ?? 99) - (b.courtNumber ?? 99) ||
+          (a.bracketPosition ?? 0) - (b.bracketPosition ?? 0),
+      )
+  }
+
+  const fallback = pending
+    .slice()
+    .sort(
+      (a, b) =>
+        (a.bracketRound - b.bracketRound) ||
+        (a.bracketPosition - b.bracketPosition),
+    )
+  return fallback.length ? [fallback[0]] : []
+}
+
+const ROUND_LABEL = {
+  [BRACKET_ROUND.QUARTERFINAL]: 'Quarterfinal',
+  [BRACKET_ROUND.SEMIFINAL]: 'Semifinal',
+  [BRACKET_ROUND.FINAL]: 'Final',
+}
+
+function BracketsSection({ brackets }) {
+  const gold = brackets.find(b => b.division === DIVISION_GOLD)
+  const silver = brackets.find(b => b.division === DIVISION_SILVER)
+  const ordered = [gold, silver].filter(Boolean)
+
+  // Tabbed view — Gold default. Keeps the section compact (no stacked
+  // 7-match trees), and gives the user a deliberate switch rather than
+  // a wall of cards to scroll through.
+  const [activeDivision, setActiveDivision] = useState(
+    gold ? DIVISION_GOLD : (silver ? DIVISION_SILVER : null),
+  )
+  const active = ordered.find(b => b.division === activeDivision) || ordered[0]
+  if (!active) return null
+
+  const champion = findChampion(active)
+  // nextUp is a LIST (concurrent matches share a time slot — see findNextUp).
+  const nextUp = champion ? [] : findNextUp(active)
+
+  return (
+    <section className="mb-10" aria-labelledby="bracket-heading">
+      <div className="flex items-center justify-between gap-3 mb-4 flex-wrap">
+        <h2
+          id="bracket-heading"
+          className="font-display text-xl font-bold text-titos-white flex items-center gap-2"
+        >
+          <Trophy className="w-5 h-5 text-titos-gold" aria-hidden="true" />
+          Playoff Brackets
+        </h2>
+        {ordered.length > 1 && (
+          <div
+            role="tablist"
+            aria-label="Select division"
+            className="inline-flex items-center gap-1 p-1 rounded-full bg-titos-elevated border border-titos-border/40"
+          >
+            {ordered.map(b => {
+              const isGold = b.division === DIVISION_GOLD
+              const isActive = b.division === activeDivision
+              const Icon = isGold ? Trophy : Medal
+              return (
+                <button
+                  key={b.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActive}
+                  onClick={() => setActiveDivision(b.division)}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 h-8 px-3 rounded-full text-xs font-bold uppercase tracking-wider transition-colors cursor-pointer',
+                    'focus:outline-none focus-visible:ring-2 focus-visible:ring-titos-gold',
+                    isActive
+                      ? (isGold
+                        ? 'bg-titos-gold text-titos-black'
+                        : 'bg-titos-white text-titos-surface')
+                      : 'text-titos-gray-400 hover:text-titos-white',
+                  )}
+                >
+                  <Icon className="w-3.5 h-3.5" aria-hidden="true" />
+                  {b.division}
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      <div className="card-flat rounded-xl overflow-hidden">
+        {/* Header band — division title + champion/next-up story */}
+        <BracketHeader bracket={active} champion={champion} nextUp={nextUp} />
+
+        {/* Tree body */}
+        <div className="p-3 sm:p-4 border-t border-titos-border/30">
+          <BracketTree matches={active.matches} />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function BracketHeader({ bracket, champion, nextUp }) {
+  const isGold = bracket.division === DIVISION_GOLD
+  const Icon = isGold ? Trophy : Medal
+  const accent = isGold ? 'text-titos-gold' : 'text-titos-gray-200'
+  const ringBg = isGold ? 'bg-titos-gold/5' : 'bg-titos-elevated/30'
+
+  return (
+    <header
+      className={cn('px-4 sm:px-5 py-3 sm:py-4 flex items-center gap-4 flex-wrap', ringBg)}
+    >
+      <div className="flex items-center gap-2 min-w-0">
+        <Icon className={cn('w-5 h-5 shrink-0', accent)} aria-hidden="true" />
+        <div className="min-w-0">
+          <div className={cn('font-display font-black text-base sm:text-lg leading-none', accent)}>
+            {bracket.division} Division
+          </div>
+          <div className="text-[11px] text-titos-gray-500 uppercase tracking-wider mt-1">
+            {bracket.matches.length} matches
+          </div>
+        </div>
+      </div>
+
+      <div className="ml-auto min-w-0 max-w-full">
+        {champion ? (
+          <ChampionCallout team={champion} />
+        ) : nextUp.length > 0 ? (
+          // Two courts play the same time slot in parallel — stack both
+          // (or all live) cards so neither gets swept off the spotlight.
+          <div className="flex flex-col sm:flex-row gap-2 items-stretch">
+            {nextUp.map((m) => (
+              <NextUpCallout key={m.id} match={m} />
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </header>
+  )
+}
+
+function ChampionCallout({ team }) {
+  return (
+    <div
+      className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-titos-gold/20 border border-titos-gold/40 text-titos-gold"
+      role="status"
+    >
+      <Crown className="w-4 h-4 shrink-0" aria-hidden="true" />
+      <span className="text-[10px] font-black uppercase tracking-wider opacity-80">Champion</span>
+      <span className="font-bold text-sm truncate max-w-[10rem] sm:max-w-none">{cleanTeamName(team.name)}</span>
+    </div>
+  )
+}
+
+function NextUpCallout({ match }) {
+  const isLive = match.status === MATCH_STATUS.LIVE
+  const home = cleanTeamName(match.homeTeam?.name) || match.homeSeedLabel || 'TBD'
+  const away = cleanTeamName(match.awayTeam?.name) || match.awaySeedLabel || 'TBD'
+  // Time intentionally omitted from the spotlight — the schedule runs in
+  // fixed slots and the concurrent-pair stacking already signals "both
+  // start together", so a repeated timestamp is noise. Court + ref are
+  // the two facts a player actually needs: where and who's on the whistle.
+  const court = match.courtNumber ? `Court ${match.courtNumber}` : null
+  const ref = cleanTeamName(match.refTeam?.name) || null
+  const round = ROUND_LABEL[match.bracketRound] || 'Match'
+
+  return (
+    <div
+      className={cn(
+        'inline-flex flex-col gap-1 px-3 py-2 rounded-lg border',
+        isLive
+          ? 'bg-status-live/10 border-status-live/30'
+          : 'bg-titos-elevated/60 border-titos-border/40',
+      )}
+    >
+      <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-wider">
+        {isLive ? (
+          <LiveIndicator />
+        ) : (
+          <span className="text-titos-gray-500">Up next</span>
+        )}
+        <span className="text-titos-gray-600" aria-hidden="true">·</span>
+        <span className="text-titos-gray-400">{round}</span>
+      </div>
+      <div className="text-sm text-titos-white font-semibold truncate max-w-[16rem] sm:max-w-xs">
+        {home} <span className="text-titos-gray-500 font-normal">vs</span> {away}
+      </div>
+      <div className="flex items-center gap-3 text-[11px] text-titos-gray-400 flex-wrap">
+        {court && (
+          <span className="inline-flex items-center gap-1">
+            <MapPin className="w-3 h-3" aria-hidden="true" />{court}
+          </span>
+        )}
+        {ref && (
+          <span className="inline-flex items-center gap-1">
+            <UserCheck className="w-3 h-3" aria-hidden="true" />Ref: {ref}
+          </span>
+        )}
+      </div>
+    </div>
   )
 }
 

--- a/components/tournament/BracketMatchMeta.js
+++ b/components/tournament/BracketMatchMeta.js
@@ -1,0 +1,146 @@
+'use client'
+
+// Admin-only inline editor for bracket match metadata (court + ref team).
+// Lives above the ScoreEntry block on the bracket admin page so whoever's
+// running the event can set "Court 2, reffed by Team X" in one place and
+// that info then renders publicly on the bracket tree for players.
+//
+// Design notes:
+//   - Deliberately compact (single row on sm+) so it doesn't dominate each
+//     match card. Ref picker defaults to "— None —" because most events
+//     assign refs only after seeding resolves.
+//   - Save is debounced per-match via a local "dirty" flag; we don't auto-
+//     save on every keystroke, since admins sometimes open the number input
+//     and tab away. Explicit Save button matches the ScoreEntry pattern.
+
+import { useState, useEffect } from 'react'
+import { Loader2, Save } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { adminPatch } from '@/lib/adminFetch'
+import { cleanTeamName } from '@/lib/tournament/displayName'
+
+export default function BracketMatchMeta({ match, slug, tournamentTeams, onSaved, flush = false }) {
+  const [court, setCourt] = useState(match.courtNumber ?? '')
+  const [refTeamId, setRefTeamId] = useState(match.refTeamId ?? '')
+  const [busy, setBusy] = useState(false)
+  const [msg, setMsg] = useState('')
+
+  // When the underlying match data refreshes (e.g. after a score save polls
+  // the server), pull the latest court/ref so the form doesn't go stale.
+  useEffect(() => {
+    setCourt(match.courtNumber ?? '')
+    setRefTeamId(match.refTeamId ?? '')
+    setMsg('')
+  }, [match.id, match.courtNumber, match.refTeamId])
+
+  const dirty =
+    String(court) !== String(match.courtNumber ?? '') ||
+    refTeamId !== (match.refTeamId ?? '')
+
+  const save = async () => {
+    setBusy(true); setMsg('')
+    try {
+      const payload = {
+        courtNumber: court === '' ? null : Number(court),
+        refTeamId: refTeamId || null,
+      }
+      const res = await adminPatch(
+        `/api/admin/tournaments/${slug}/bracket-matches/${match.id}`,
+        payload,
+      )
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setMsg(data.error || 'Failed')
+      } else {
+        setMsg('Saved')
+        onSaved?.(data)
+      }
+    } catch {
+      setMsg('Connection error')
+    }
+    setBusy(false)
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex flex-wrap items-end gap-2 px-3 py-2',
+        flush
+          ? 'border-b border-titos-border/30 bg-titos-elevated/20'
+          : 'rounded-lg border border-titos-border/40 bg-titos-elevated/30',
+      )}
+    >
+      <div className="flex flex-col gap-1 min-w-[5rem]">
+        <label
+          htmlFor={`court-${match.id}`}
+          className="text-[10px] font-bold uppercase tracking-wider text-titos-gray-500"
+        >
+          Court
+        </label>
+        <input
+          id={`court-${match.id}`}
+          type="number"
+          inputMode="numeric"
+          min="1"
+          max="99"
+          step="1"
+          value={court}
+          onChange={(e) => setCourt(e.target.value)}
+          placeholder="—"
+          className="h-9 w-20 px-2 rounded border border-titos-border bg-titos-surface text-center text-titos-white text-sm font-bold tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-titos-gold"
+        />
+      </div>
+
+      <div className="flex flex-col gap-1 flex-1 min-w-[10rem]">
+        <label
+          htmlFor={`ref-${match.id}`}
+          className="text-[10px] font-bold uppercase tracking-wider text-titos-gray-500"
+        >
+          Ref team
+        </label>
+        <select
+          id={`ref-${match.id}`}
+          value={refTeamId}
+          onChange={(e) => setRefTeamId(e.target.value)}
+          className="h-9 px-2 rounded border border-titos-border bg-titos-surface text-titos-white text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-titos-gold cursor-pointer"
+        >
+          <option value="">— None —</option>
+          {tournamentTeams.map(t => (
+            <option key={t.id} value={t.id}>{cleanTeamName(t.name)}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {msg && (
+          <span
+            className={cn(
+              'text-[11px]',
+              msg === 'Saved' ? 'text-status-success' : 'text-titos-gray-400',
+            )}
+            role="status"
+            aria-live="polite"
+          >
+            {msg}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={save}
+          disabled={busy || !dirty}
+          aria-label="Save court and ref"
+          className={cn(
+            'h-9 px-3 rounded text-xs font-semibold inline-flex items-center gap-1.5 cursor-pointer transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-titos-gold',
+            dirty && !busy
+              ? 'bg-titos-gold text-titos-black hover:bg-titos-gold/90'
+              : 'bg-titos-elevated text-titos-gray-500 cursor-not-allowed',
+          )}
+        >
+          {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" aria-hidden="true" /> : <Save className="w-3.5 h-3.5" aria-hidden="true" />}
+          Save
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/components/tournament/BracketTree.js
+++ b/components/tournament/BracketTree.js
@@ -1,6 +1,28 @@
 // Horizontal bracket layout: round columns (QF → SF → F) with MatchCards.
-// Lightweight grid; design pass will add connector lines + better spacing.
+//
+// Layout choices:
+//   - Horizontal scroll on small screens (cards keep a minimum 14rem width so
+//     they never get squeezed illegible). `overflow-x-auto` gives a native
+//     swipe affordance — no JS pager needed.
+//   - Round columns grow with breakpoints (14rem → 15rem → 16rem) so on a
+//     laptop all three columns fit without scroll.
+//   - Subtle arrow glyph between columns visually communicates "winners
+//     advance this way" without expensive SVG connectors.
+//   - Round header is a pill badge so scanning "which column am I looking
+//     at?" is trivial from ten feet away.
+//
+// QF grouping nuance (important — see screenshot feedback):
+//   The PDF schedule runs an INTERLEAVED QF order on the physical courts
+//   (QF1 and QF3 both play Court 1, QF2 and QF4 both play Court 2). That
+//   means SF1 is fed by QF1 + QF3 — not QF1 + QF2 as a naive 1-2-3-4 stack
+//   would suggest. If we render QFs strictly by bracketPosition the tree
+//   reads wrong ("SZN wins QF1, how does its winner end up against QF3's
+//   winner and not QF2's?"). So for the QF column we group by SF-feed
+//   (position % sfCount) and render each group as a visually-tight pair
+//   with a larger gap BETWEEN groups. The SF column next to it can then
+//   line up with the centre of each pair and the feed reads correctly.
 
+import { ChevronRight } from 'lucide-react'
 import MatchCard from './MatchCard'
 import { BRACKET_ROUND } from '@/lib/tournament/constants'
 
@@ -24,24 +46,74 @@ export default function BracketTree({ matches }) {
     return <p className="text-titos-gray-500 text-sm">No matches yet.</p>
   }
 
+  // QFs feed SFs via `position % sfCount` (see admin/brackets/route.js).
+  // Pre-group the QF list into feed-buckets so the render below can slot
+  // each bucket as a tight visual pair.
+  const qfList = byRound[BRACKET_ROUND.QUARTERFINAL] || []
+  const sfCount = Math.max(1, Math.ceil(qfList.length / 2))
+  const qfGroups = Array.from({ length: sfCount }, (_, gi) =>
+    qfList
+      .filter((m) => ((m.bracketPosition ?? 0) % sfCount) === gi)
+      .sort((a, b) => (a.bracketPosition ?? 0) - (b.bracketPosition ?? 0)),
+  )
+
   return (
-    <div className="overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0">
-      <div className="flex gap-4 sm:gap-8 items-start min-w-fit">
-        {rounds.map(r => {
-          // Sort by bracketPosition for stable vertical order
-          const list = [...byRound[r]].sort((a, b) => (a.bracketPosition ?? 0) - (b.bracketPosition ?? 0))
+    <div className="overflow-x-auto -mx-3 px-3 sm:mx-0 sm:px-0 pb-1" aria-label="Bracket tree">
+      <div className="flex items-stretch gap-2 sm:gap-3 md:gap-4 min-w-fit">
+        {rounds.map((r, idx) => {
+          const isQf = r === BRACKET_ROUND.QUARTERFINAL
+          const isFinal = r === BRACKET_ROUND.FINAL
+          const list = [...byRound[r]].sort(
+            (a, b) => (a.bracketPosition ?? 0) - (b.bracketPosition ?? 0),
+          )
           return (
-            <div key={r} className="flex flex-col gap-2">
-              <span className="text-[10px] font-bold uppercase tracking-wider text-titos-gray-500 text-center mb-2">
-                {LABELS[r] || `Round ${r}`}
-              </span>
-              <div className="flex flex-col gap-4 sm:gap-6" style={{ justifyContent: 'space-around' }}>
-                {list.map(m => (
-                  <div key={m.id} className="w-[14rem] sm:w-56">
-                    <MatchCard match={m} variant="bracket" />
+            <div key={r} className="flex items-stretch gap-2 sm:gap-3 md:gap-4">
+              <div className="flex flex-col gap-3">
+                {/* Round header pill */}
+                <div className="flex justify-center">
+                  <span
+                    className="inline-flex items-center px-2.5 py-1 rounded-full bg-titos-elevated border border-titos-border/40 text-[10px] font-black uppercase tracking-wider text-titos-gray-300"
+                  >
+                    {LABELS[r] || `Round ${r}`}
+                  </span>
+                </div>
+                {/* Match column.
+                    QFs render in paired groups so each pair visually "feeds"
+                    the SF next to it (tight inner gap, loose outer gap). Non-
+                    QF rounds keep the simple evenly-distributed column. */}
+                {isQf ? (
+                  <div className="flex flex-col gap-8 sm:gap-10 md:gap-12 justify-around flex-1">
+                    {qfGroups.map((group, gi) => (
+                      <div key={gi} className="flex flex-col gap-2 sm:gap-3">
+                        {group.map((m) => (
+                          <div key={m.id} className="w-[14.5rem] sm:w-60 md:w-64">
+                            <MatchCard match={m} variant="bracket" />
+                          </div>
+                        ))}
+                      </div>
+                    ))}
                   </div>
-                ))}
+                ) : (
+                  <div
+                    className={
+                      'flex flex-col gap-4 sm:gap-5 md:gap-6 flex-1 ' +
+                      (isFinal ? 'justify-center' : 'justify-around')
+                    }
+                  >
+                    {list.map((m) => (
+                      <div key={m.id} className="w-[14.5rem] sm:w-60 md:w-64">
+                        <MatchCard match={m} variant="bracket" />
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
+              {/* Inter-column advance arrow (hidden after final column) */}
+              {idx < rounds.length - 1 && (
+                <div className="flex items-center" aria-hidden="true">
+                  <ChevronRight className="w-5 h-5 text-titos-gray-600" />
+                </div>
+              )}
             </div>
           )
         })}

--- a/components/tournament/LiveMatchCard.js
+++ b/components/tournament/LiveMatchCard.js
@@ -7,6 +7,7 @@
 import { cn } from '@/lib/utils'
 import LiveIndicator from './LiveIndicator'
 import { tallySetsWon } from '@/lib/tournament/computeMatchStatus'
+import { cleanTeamName } from '@/lib/tournament/displayName'
 
 function fmtTime(date) {
   if (!date) return null
@@ -21,8 +22,8 @@ function fmtTime(date) {
 }
 
 export default function LiveMatchCard({ match, poolName }) {
-  const home = match.homeTeam?.name || match.homeSeedLabel || 'Home'
-  const away = match.awayTeam?.name || match.awaySeedLabel || 'Away'
+  const home = cleanTeamName(match.homeTeam?.name) || match.homeSeedLabel || 'Home'
+  const away = cleanTeamName(match.awayTeam?.name) || match.awaySeedLabel || 'Away'
 
   const sortedScores = (match.scores || [])
     .slice()

--- a/components/tournament/MatchCard.js
+++ b/components/tournament/MatchCard.js
@@ -2,14 +2,17 @@
 // set scores, and status. Uses data-* attributes so styles in the design pass
 // can target status/variant without prop drilling.
 //
-// When `poolTeams` is passed for a pool match, a "Ref" footer is rendered
-// showing the single team on whistle duty (per the April 25 Captains Package
-// schedule — one ref per match, not a lead+line pair).
+// Ref footer resolution order:
+//   1. `match.refTeam` — manual admin assignment (works for any match)
+//   2. `poolTeams` rotation — derived from the Captains Package PDF (pool only)
+// Bracket matches rely exclusively on (1); there is no automatic rotation.
 
+import { MapPin, UserCheck } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import LiveIndicator from './LiveIndicator'
 import { refAssignmentForMatch } from '@/lib/tournament/refRotation'
 import { tallySetsWon, setWinnerAt } from '@/lib/tournament/computeMatchStatus'
+import { cleanTeamName } from '@/lib/tournament/displayName'
 
 function fmtTime(date) {
   if (!date) return null
@@ -20,14 +23,18 @@ function fmtTime(date) {
   }
 }
 
-export default function MatchCard({ match, variant = 'pool', poolTeams = null }) {
-  const home = match.homeTeam?.name || match.homeSeedLabel || 'TBD'
-  const away = match.awayTeam?.name || match.awaySeedLabel || 'TBD'
+export default function MatchCard({ match, variant = 'pool', poolTeams = null, showRound = false }) {
+  const home = cleanTeamName(match.homeTeam?.name) || match.homeSeedLabel || 'TBD'
+  const away = cleanTeamName(match.awayTeam?.name) || match.awaySeedLabel || 'TBD'
 
-  // Ref assignment (pool matches only — brackets don't auto-rotate refs).
-  const refs = variant === 'pool' && poolTeams
-    ? refAssignmentForMatch(match, poolTeams)
-    : null
+  // Ref assignment: prefer the manually-assigned `refTeam` (works for both
+  // pool overrides and bracket matches); otherwise derive from the PDF
+  // rotation when we have a pool roster. Falls back to null (no ref line).
+  let refName = cleanTeamName(match.refTeam?.name) ?? null
+  if (!refName && variant === 'pool' && poolTeams) {
+    const derived = refAssignmentForMatch(match, poolTeams)
+    refName = cleanTeamName(derived?.ref?.name) ?? null
+  }
 
   // Normalize scores once; we render per-set columns for richer live display.
   const sortedScores = (match.scores || [])
@@ -44,8 +51,22 @@ export default function MatchCard({ match, variant = 'pool', poolTeams = null })
   const awayWon = match.status === 'completed' && match.winnerId && match.winnerId === match.awayTeamId
 
   const time = fmtTime(match.scheduledTime)
-  const court = match.courtNumber ? `Court ${match.courtNumber}` : null
-  const meta = [time, court].filter(Boolean).join(' · ')
+  const courtNumber = match.courtNumber ?? null
+  const court = courtNumber ? `Court ${courtNumber}` : null
+  // Round chip only renders when caller opts in (showRound). The public
+  // hub passes showRound so the single-dropdown pool view keeps R1/R2/…
+  // legible without re-introducing per-round accordions.
+  const roundLabel = showRound && match.roundNumber ? `R${match.roundNumber}` : null
+  // Bracket cards deliberately omit the time — the bracket tree reads
+  // round-to-round ("when" is "after the previous match finishes") and
+  // the single-day playoff schedule makes per-card timestamps noise more
+  // than signal. The "Up next" spotlight above the tree still surfaces
+  // the concrete time for whichever slot is next. Court stays in its own
+  // badge so the physical location is always visible.
+  const metaParts = variant === 'bracket'
+    ? [roundLabel]
+    : [roundLabel, time, court]
+  const meta = metaParts.filter(Boolean).join(' · ')
 
   return (
     <article
@@ -53,6 +74,12 @@ export default function MatchCard({ match, variant = 'pool', poolTeams = null })
       data-variant={variant}
       data-status={match.status}
     >
+      {/* Meta row — status + court badge for bracket cards (no time),
+          status · round · time · court for pool cards.
+          The bracket card is 14.5rem wide, so we deliberately DROP the
+          per-set column headers (S1/S2/S3) that pool cards show. Set
+          numbers are implicit in their left-to-right order and the
+          headers were otherwise stealing space in a narrow card. */}
       <div className="flex items-center justify-between px-3 py-1.5 border-b border-titos-border/30 gap-2">
         <div className="flex items-center gap-2 min-w-0">
           {match.status === 'live' ? (
@@ -64,13 +91,30 @@ export default function MatchCard({ match, variant = 'pool', poolTeams = null })
           )}
           {meta && <span className="text-[10px] text-titos-gray-500 truncate">{meta}</span>}
         </div>
-        {sortedScores.length > 0 && (
-          <div className="flex items-center gap-1 text-[10px] text-titos-gray-500 font-medium uppercase tracking-wider shrink-0">
-            {sortedScores.map(s => (
-              <span key={s.setNumber} className="min-w-[1.75rem] sm:min-w-[2.5rem] text-center">S{s.setNumber}</span>
-            ))}
-          </div>
-        )}
+        <div className="flex items-center gap-2 shrink-0">
+          {/* Pool-card set-column headers (S1/S2/S3) only — keeps a wide
+              pool card legible without crowding the narrower bracket one. */}
+          {variant === 'pool' && sortedScores.length > 0 && (
+            <div className="flex items-center gap-1 text-[10px] text-titos-gray-500 font-medium uppercase tracking-wider">
+              {sortedScores.map(s => (
+                <span key={s.setNumber} className="min-w-[1.75rem] sm:min-w-[2.5rem] text-center">
+                  S{s.setNumber}
+                </span>
+              ))}
+            </div>
+          )}
+          {/* Bracket court badge — pulled out so the physical court where
+              this match plays is obvious at a glance, not buried in meta. */}
+          {variant === 'bracket' && courtNumber && (
+            <span
+              className="inline-flex items-center gap-1 h-5 px-1.5 rounded-md bg-titos-gold/15 text-titos-gold text-[10px] font-bold tabular-nums"
+              aria-label={`Court ${courtNumber}`}
+            >
+              <MapPin className="w-3 h-3" aria-hidden="true" />
+              C{courtNumber}
+            </span>
+          )}
+        </div>
       </div>
       <div className="divide-y divide-titos-border/20">
         <TeamRow
@@ -92,10 +136,11 @@ export default function MatchCard({ match, variant = 'pool', poolTeams = null })
           mode={mode}
         />
       </div>
-      {refs?.ref && (
+      {refName && (
         <div className="px-3 py-1.5 border-t border-titos-border/30 bg-titos-elevated/40 text-[11px] text-titos-gray-400 flex items-center gap-1.5">
-          <span className="font-semibold uppercase tracking-wider text-titos-gray-500">Ref</span>
-          <span className="text-titos-gray-300 truncate">{refs.ref.name}</span>
+          <UserCheck className="w-3 h-3 text-titos-gray-500 shrink-0" aria-hidden="true" />
+          <span className="font-semibold uppercase tracking-wider text-titos-gray-500 text-[10px]">Ref</span>
+          <span className="text-titos-gray-200 font-medium truncate">{refName}</span>
         </div>
       )}
     </article>
@@ -104,8 +149,18 @@ export default function MatchCard({ match, variant = 'pool', poolTeams = null })
 
 function TeamRow({ name, winner, setsWon, perSet, opposingPerSet, showNumbers, mode }) {
   return (
-    <div className={cn('flex items-center justify-between px-3 py-2 gap-2 sm:gap-3', winner && 'bg-titos-gold/10')}>
-      <span className={cn('text-sm truncate flex-1 min-w-0', winner ? 'text-titos-gold font-bold' : 'text-titos-white')}>
+    <div
+      className={cn(
+        'flex items-center justify-between px-3 py-2 gap-2 sm:gap-3',
+        winner && 'bg-titos-gold/10',
+      )}
+    >
+      <span
+        className={cn(
+          'text-sm truncate flex-1 min-w-0',
+          winner ? 'text-titos-gold font-bold' : 'text-titos-white',
+        )}
+      >
         {name}
       </span>
       {showNumbers && (
@@ -114,25 +169,43 @@ function TeamRow({ name, winner, setsWon, perSet, opposingPerSet, showNumbers, m
             // Only emphasise the winner's score once the set is actually
             // complete — a mid-set lead stays neutral. Reconstructing as
             // {homeScore=me, awayScore=them}, a 'home' winner means this side.
-            const wonSet = setWinnerAt(
-              { homeScore: pts, awayScore: opposingPerSet[i] ?? 0 },
-              i,
-              mode,
-            ) === 'home'
+            const wonSet =
+              setWinnerAt(
+                { homeScore: pts, awayScore: opposingPerSet[i] ?? 0 },
+                i,
+                mode,
+              ) === 'home'
             return (
               <span
                 key={i}
-                className={cn('min-w-[1.75rem] sm:min-w-[2.5rem] text-center text-sm tabular-nums font-semibold',
-                  wonSet ? 'text-titos-white' : 'text-titos-gray-500',
+                className={cn(
+                  'min-w-[1.75rem] sm:min-w-[2.5rem] text-center text-sm tabular-nums',
+                  // Step up the emphasis for winning scores: bold + full
+                  // white; losing scores drop to semibold gray so the set
+                  // winner pops at a glance without needing the S1/S2/S3
+                  // column headers to parse the readout.
+                  wonSet
+                    ? 'font-bold text-titos-white'
+                    : 'font-medium text-titos-gray-500',
                 )}
               >
                 {pts}
               </span>
             )
           })}
-          <span className={cn('min-w-[1.5rem] sm:min-w-[2rem] text-center text-sm font-bold tabular-nums pl-1.5 sm:pl-2 border-l border-titos-border/40',
-            winner ? 'text-titos-gold' : 'text-titos-gray-300',
-          )}>
+          {/* Sets-won total — pill-ified with its own bg so the divider
+              isn't the only affordance separating "score of set 3" from
+              "total sets won". Makes the column read as a clear summary,
+              not another set score. */}
+          <span
+            className={cn(
+              'ml-1 sm:ml-1.5 inline-flex items-center justify-center min-w-[1.75rem] sm:min-w-[2rem] h-7 px-1.5 rounded-md text-sm font-black tabular-nums',
+              winner
+                ? 'bg-titos-gold/25 text-titos-gold ring-1 ring-titos-gold/40'
+                : 'bg-titos-elevated/60 text-titos-gray-300',
+            )}
+            aria-label={`${setsWon} set${setsWon === 1 ? '' : 's'} won`}
+          >
             {setsWon}
           </span>
         </div>

--- a/components/tournament/PoolMatchesList.js
+++ b/components/tournament/PoolMatchesList.js
@@ -1,0 +1,96 @@
+'use client'
+
+// Single-dropdown per pool: one <details> containing every match in round
+// order. Default open so users see everything without clicking; collapse is
+// a one-click escape hatch when they want the standings table to breathe.
+//
+// Earlier revision used a dropdown per round (R1, R2, …). On a 4-pool event
+// that was 24 separate disclosures — clicking fatigue, not less clicking.
+// Round grouping is now conveyed passively: each MatchCard's meta line
+// already carries the round number (via the `showRound` prop) so scanning
+// stays trivial without forcing users to open/close anything.
+//
+// Native <details>/<summary> — keyboard + screen-reader semantics come
+// free, no JS state, no layout shift.
+
+import { useMemo } from 'react'
+import { ChevronDown } from 'lucide-react'
+import MatchCard from './MatchCard'
+
+function summarize(matches) {
+  let live = 0
+  let final = 0
+  let scheduled = 0
+  for (const m of matches) {
+    if (m.status === 'live') live++
+    else if (m.status === 'completed') final++
+    else scheduled++
+  }
+  return { live, final, scheduled }
+}
+
+export default function PoolMatchesList({ matches, poolTeams }) {
+  const sorted = useMemo(() => {
+    return (matches || []).slice().sort((a, b) => {
+      const ra = a.roundNumber ?? 0
+      const rb = b.roundNumber ?? 0
+      if (ra !== rb) return ra - rb
+      return (a.gameOrder ?? 0) - (b.gameOrder ?? 0)
+    })
+  }, [matches])
+
+  const summary = useMemo(() => summarize(sorted), [sorted])
+
+  if (sorted.length === 0) {
+    return <p className="text-titos-gray-500 text-xs px-1">No matches scheduled yet.</p>
+  }
+
+  return (
+    <details open className="group card-flat rounded-lg overflow-hidden">
+      <summary className="list-none cursor-pointer select-none px-3 py-2 flex items-center gap-2 hover:bg-titos-elevated/40 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-titos-gold">
+        <ChevronDown
+          className="w-4 h-4 text-titos-gray-400 shrink-0 transition-transform duration-200 group-open:rotate-180"
+          aria-hidden="true"
+        />
+        <span className="font-display font-bold text-titos-white text-sm">
+          Matches
+        </span>
+        <span className="text-[10px] text-titos-gray-500 ml-auto flex items-center gap-2">
+          <span>{sorted.length} total</span>
+          {summary.live > 0 && (
+            <>
+              <span className="text-titos-gray-600" aria-hidden="true">·</span>
+              <span className="inline-flex items-center gap-1 text-status-live font-bold uppercase tracking-wider">
+                <span className="w-1.5 h-1.5 rounded-full bg-status-live animate-pulse" aria-hidden="true" />
+                {summary.live} live
+              </span>
+            </>
+          )}
+          {summary.final > 0 && (
+            <>
+              <span className="text-titos-gray-600" aria-hidden="true">·</span>
+              <span>{summary.final} final</span>
+            </>
+          )}
+          {summary.scheduled > 0 && (
+            <>
+              <span className="text-titos-gray-600" aria-hidden="true">·</span>
+              <span>{summary.scheduled} upcoming</span>
+            </>
+          )}
+        </span>
+      </summary>
+      <div className="px-2 pb-2 pt-1 space-y-1.5 border-t border-titos-border/30">
+        {sorted.map(m => (
+          <MatchCard
+            key={m.id}
+            match={m}
+            variant="pool"
+            poolTeams={poolTeams}
+            showRound
+          />
+        ))}
+      </div>
+    </details>
+  )
+}

--- a/components/tournament/ScoreEntry.js
+++ b/components/tournament/ScoreEntry.js
@@ -24,11 +24,12 @@
 //     aria-live="polite") on save results.
 
 import { useState, useEffect } from 'react'
-import { Loader2, Save, Minus, Plus, ChevronDown, ChevronUp } from 'lucide-react'
+import { Loader2, Save, Minus, Plus, ChevronDown, ChevronUp, Trash2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import { adminPatch } from '@/lib/adminFetch'
+import { adminPatch, adminDelete } from '@/lib/adminFetch'
 import { refAssignmentForMatch } from '@/lib/tournament/refRotation'
 import { tallySetsWon } from '@/lib/tournament/computeMatchStatus'
+import { cleanTeamName } from '@/lib/tournament/displayName'
 
 function statusChip(status) {
   if (status === 'completed') {
@@ -59,7 +60,7 @@ function clampScore(v) {
   return Math.round(n)
 }
 
-export default function ScoreEntry({ match, saveUrl, onSaved, poolTeams = null }) {
+export default function ScoreEntry({ match, saveUrl, onSaved, poolTeams = null, flush = false }) {
   const setCount = match.poolId ? 2 : 3
   const buildInitial = () => Array.from({ length: setCount }).map((_, i) => {
     const s = match.scores?.find(x => x.setNumber === i + 1)
@@ -68,13 +69,18 @@ export default function ScoreEntry({ match, saveUrl, onSaved, poolTeams = null }
   const [sets, setSets] = useState(buildInitial)
   const [busy, setBusy] = useState(false)
   const [msg, setMsg] = useState('')
-  // Default to collapsed for FINAL matches — admins rarely need to edit them.
-  const [expanded, setExpanded] = useState(match.status !== 'completed')
+  // Default collapsed except for LIVE matches — bracket admin pages render
+  // 14 matches (4 QF + 2 SF + 1 F per division) and expanding them all by
+  // default made the page scroll ~8000px. LIVE stays open because that's
+  // the one the admin is actively editing; everything else opens on click.
+  const [expanded, setExpanded] = useState(match.status === 'live')
 
   useEffect(() => {
     setSets(buildInitial())
-    // If the status flips to FINAL out-of-band, collapse; if it reopens, expand.
-    setExpanded(match.status !== 'completed')
+    // Re-sync when the match status flips. LIVE auto-expands, everything
+    // else collapses back unless the admin already opened it — we only
+    // force state on real transitions, never mid-edit.
+    setExpanded(match.status === 'live')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [match.id, match.scores?.length, match.status, setCount])
 
@@ -115,8 +121,39 @@ export default function ScoreEntry({ match, saveUrl, onSaved, poolTeams = null }
     setBusy(false)
   }
 
-  const home = match.homeTeam?.name || match.homeSeedLabel || 'TBD'
-  const away = match.awayTeam?.name || match.awaySeedLabel || 'TBD'
+  // Wipe all saved scores for this match and reset it to SCHEDULED. On the
+  // bracket side this also best-effort un-advances any winner into the next
+  // round + clears auto-assigned refs downstream (handled server-side).
+  // Guarded with a native confirm() because this is destructive and can
+  // invalidate downstream matches if they've already started.
+  const hasSavedScores = (match.scores?.length ?? 0) > 0
+  const clear = async () => {
+    if (typeof window !== 'undefined') {
+      const ok = window.confirm(
+        'Clear all scores for this match? This will reset the match to scheduled and cannot be undone.',
+      )
+      if (!ok) return
+    }
+    setBusy(true); setMsg('')
+    try {
+      const res = await adminDelete(saveUrl)
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        setMsg(data.error || 'Failed')
+      } else {
+        // Reset the local inputs to blanks so the UI matches the server.
+        setSets(Array.from({ length: setCount }).map((_, i) => ({
+          setNumber: i + 1, homeScore: '', awayScore: '',
+        })))
+        setMsg('Cleared')
+        onSaved?.(data)
+      }
+    } catch { setMsg('Connection error') }
+    setBusy(false)
+  }
+
+  const home = cleanTeamName(match.homeTeam?.name) || match.homeSeedLabel || 'TBD'
+  const away = cleanTeamName(match.awayTeam?.name) || match.awaySeedLabel || 'TBD'
   const refs = match.poolId && poolTeams ? refAssignmentForMatch(match, poolTeams) : null
 
   // Set-win tally for the header chip ("Home 2 – 0 Away"). Only completed
@@ -138,7 +175,13 @@ export default function ScoreEntry({ match, saveUrl, onSaved, poolTeams = null }
   const meta = [match.roundNumber ? `R${match.roundNumber}` : null, time, court].filter(Boolean).join(' · ')
 
   return (
-    <div className="card-flat rounded-lg overflow-hidden" data-status={match.status}>
+    <div
+      className={cn(
+        'overflow-hidden',
+        flush ? 'bg-transparent' : 'card-flat rounded-lg',
+      )}
+      data-status={match.status}
+    >
       {/* Header — always visible. Clicking toggles collapse. */}
       <button
         type="button"
@@ -149,9 +192,17 @@ export default function ScoreEntry({ match, saveUrl, onSaved, poolTeams = null }
       >
         {/* Mobile-first layout: status chip + meta on row 1, teams + tally on
             row 2. Keeps every line ≥14px + avoids horizontal truncation that
-            made long team names unreadable at 375px. */}
+            made long team names unreadable at 375px.
+            When `flush`, the parent wrapper already shows status+teams as its
+            own identity strip, so we drop the duplicate team row and keep
+            only the compact meta/tally/chevron line here. */}
         <div className="flex items-center gap-2 mb-1.5">
-          {statusChip(match.status)}
+          {!flush && statusChip(match.status)}
+          {flush && (
+            <span className="text-[10px] font-bold uppercase tracking-wider text-titos-gray-500">
+              {expanded ? 'Hide scores' : 'Enter scores'}
+            </span>
+          )}
           {meta && <span className="text-[10px] text-titos-gray-500 truncate flex-1">{meta}</span>}
           {(tally.home > 0 || tally.away > 0) && (
             <span className="text-sm font-bold tabular-nums text-titos-white shrink-0">
@@ -162,11 +213,13 @@ export default function ScoreEntry({ match, saveUrl, onSaved, poolTeams = null }
             ? <ChevronUp className="w-4 h-4 text-titos-gray-400 shrink-0" aria-hidden="true" />
             : <ChevronDown className="w-4 h-4 text-titos-gray-400 shrink-0" aria-hidden="true" />}
         </div>
-        <div className="text-sm text-titos-white leading-snug">
-          <span className={cn('break-words', tally.home > tally.away && 'text-titos-gold font-semibold')}>{home}</span>
-          <span className="text-titos-gray-600 mx-1.5">vs</span>
-          <span className={cn('break-words', tally.away > tally.home && 'text-titos-gold font-semibold')}>{away}</span>
-        </div>
+        {!flush && (
+          <div className="text-sm text-titos-white leading-snug">
+            <span className={cn('break-words', tally.home > tally.away && 'text-titos-gold font-semibold')}>{home}</span>
+            <span className="text-titos-gray-600 mx-1.5">vs</span>
+            <span className={cn('break-words', tally.away > tally.home && 'text-titos-gold font-semibold')}>{away}</span>
+          </div>
+        )}
       </button>
 
       {expanded && (
@@ -177,7 +230,7 @@ export default function ScoreEntry({ match, saveUrl, onSaved, poolTeams = null }
           {refs?.ref && (
             <p className="text-[11px] text-titos-gray-400">
               <span className="font-semibold uppercase tracking-wider text-titos-gray-500">Ref: </span>
-              <span className="text-titos-gray-300">{refs.ref.name}</span>
+              <span className="text-titos-gray-300">{cleanTeamName(refs.ref.name)}</span>
             </p>
           )}
 
@@ -196,27 +249,45 @@ export default function ScoreEntry({ match, saveUrl, onSaved, poolTeams = null }
             />
           ))}
 
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-end gap-2 sm:gap-3 pt-1">
-            {msg && (
-              <span
-                className={cn(
-                  'text-xs order-last sm:order-none text-center sm:text-left',
-                  msg === 'Saved' ? 'text-status-success' : 'text-titos-gray-400',
-                )}
-                role="status"
-                aria-live="polite"
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 pt-1">
+            {/* Clear button lives on the left — visually separated from the
+                primary Save CTA so it's never confused with it. Only shown
+                once the match has saved scores to clear. */}
+            {hasSavedScores ? (
+              <button
+                type="button"
+                onClick={clear}
+                disabled={busy}
+                aria-label="Clear all saved scores for this match"
+                className="text-xs py-2 px-3 min-h-[40px] inline-flex items-center justify-center gap-1.5 rounded border border-titos-border/60 text-titos-gray-300 hover:text-status-error hover:border-status-error/60 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-status-error disabled:opacity-50 disabled:cursor-not-allowed w-full sm:w-auto"
               >
-                {msg}
-              </span>
-            )}
-            <button
-              onClick={save}
-              disabled={busy}
-              aria-label="Save scores"
-              className="btn-primary text-sm py-2.5 px-5 min-h-[44px] w-full sm:w-auto inline-flex items-center justify-center gap-1.5 cursor-pointer"
-            >
-              {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <><Save className="w-4 h-4" /> Save</>}
-            </button>
+                <Trash2 className="w-3.5 h-3.5" aria-hidden="true" />
+                Clear scores
+              </button>
+            ) : <span className="hidden sm:block" aria-hidden="true" />}
+
+            <div className="flex items-center gap-3 sm:justify-end">
+              {msg && (
+                <span
+                  className={cn(
+                    'text-xs order-last sm:order-none text-center sm:text-left',
+                    (msg === 'Saved' || msg === 'Cleared') ? 'text-status-success' : 'text-titos-gray-400',
+                  )}
+                  role="status"
+                  aria-live="polite"
+                >
+                  {msg}
+                </span>
+              )}
+              <button
+                onClick={save}
+                disabled={busy}
+                aria-label="Save scores"
+                className="btn-primary text-sm py-2.5 px-5 min-h-[44px] w-full sm:w-auto inline-flex items-center justify-center gap-1.5 cursor-pointer"
+              >
+                {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <><Save className="w-4 h-4" /> Save</>}
+              </button>
+            </div>
           </div>
         </div>
       )}
@@ -287,10 +358,6 @@ function SetRow({ setNumber, home, away, homeScore, awayScore, onChange, onBump,
         </button>
       </div>
 
-      <p className="mt-2 text-[10px] text-titos-gray-500 hidden md:block">
-        Tip: <kbd className="font-mono text-titos-gray-400">↑</kbd>/<kbd className="font-mono text-titos-gray-400">↓</kbd> adjust by 1,
-        {' '}<kbd className="font-mono text-titos-gray-400">Shift</kbd>+arrow by 5
-      </p>
     </fieldset>
   )
 }

--- a/components/tournament/StandingsTable.js
+++ b/components/tournament/StandingsTable.js
@@ -7,39 +7,51 @@
 // SW leads because it's the primary standings currency; ties on SW break on
 // head-to-head point differential (surfaced in the +/- column).
 //
+// Qualifier clarity: earlier designs used Trophy / Medal icons next to the
+// rank, which confused users ("why does 1st have a different icon than 2nd?"
+// / "does a medal mean silver?"). Replaced with an explicit "Advances" column
+// that spells out the destination bracket in words — no ambiguity.
+//
 // When `selectedTeamId` is provided (player has picked their team via the
 // TeamPicker), that team's row is visually highlighted and annotated with a
 // "YOU" chip so players can find themselves at a glance in a dense grid.
 
-import { Trophy, Medal } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { cleanTeamName } from '@/lib/tournament/displayName'
 
-// Left-accent colors + icon per qualifying status. Keeping all visual decisions
-// derived from `qualifies` means the calculation stays the single source of
-// truth — the UI can never disagree with the standings logic.
-function rankMeta(qualifies, index) {
+// Derive left-accent border + rank color from the qualifying status. Keeping
+// all visual decisions tied to `qualifies` means the UI can never disagree
+// with the computed standings.
+function rowAccent(qualifies) {
+  if (qualifies === 'gold') return { accent: 'border-l-2 border-titos-gold/60', rankClass: 'text-titos-gold' }
+  if (qualifies === 'silver') return { accent: 'border-l-2 border-titos-gray-400/50', rankClass: 'text-titos-gray-200' }
+  return { accent: 'border-l-2 border-transparent', rankClass: 'text-titos-gray-500' }
+}
+
+function AdvanceBadge({ qualifies }) {
   if (qualifies === 'gold') {
-    return {
-      accent: 'border-l-2 border-titos-gold/60',
-      rankClass: 'text-titos-gold',
-      icon: index === 0 ? Trophy : Medal,
-      iconClass: 'text-titos-gold',
-    }
+    return (
+      <span
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-titos-gold/15 text-titos-gold text-[10px] font-bold uppercase tracking-wider whitespace-nowrap"
+        title="Top 2 in this pool advance to the Gold bracket"
+      >
+        <span className="w-1.5 h-1.5 rounded-full bg-titos-gold" aria-hidden="true" />
+        Gold
+      </span>
+    )
   }
   if (qualifies === 'silver') {
-    return {
-      accent: 'border-l-2 border-titos-gray-500/50',
-      rankClass: 'text-titos-gray-300',
-      icon: null,
-      iconClass: '',
-    }
+    return (
+      <span
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-titos-gray-500/15 text-titos-gray-200 text-[10px] font-bold uppercase tracking-wider whitespace-nowrap"
+        title="Bottom 2 in this pool drop into the Silver bracket"
+      >
+        <span className="w-1.5 h-1.5 rounded-full bg-titos-gray-300" aria-hidden="true" />
+        Silver
+      </span>
+    )
   }
-  return {
-    accent: 'border-l-2 border-transparent',
-    rankClass: 'text-titos-gray-500',
-    icon: null,
-    iconClass: '',
-  }
+  return <span className="text-titos-gray-600 text-xs" aria-label="Does not advance">—</span>
 }
 
 export default function StandingsTable({ pool, standings, selectedTeamId = null }) {
@@ -51,15 +63,10 @@ export default function StandingsTable({ pool, standings, selectedTeamId = null 
         <div className="flex items-center justify-between gap-2 flex-wrap">
           <h3 className="font-display font-bold text-titos-gold text-sm">{pool.name}</h3>
           {hasGoldSilver && (
-            <div className="flex items-center gap-3 text-[9px] uppercase tracking-wider">
-              <span className="inline-flex items-center gap-1 text-titos-gold">
-                <span className="w-1.5 h-1.5 rounded-full bg-titos-gold" aria-hidden="true" />
-                Gold bracket
-              </span>
-              <span className="inline-flex items-center gap-1 text-titos-gray-400">
-                <span className="w-1.5 h-1.5 rounded-full bg-titos-gray-500" aria-hidden="true" />
-                Silver bracket
-              </span>
+            <div className="flex items-center gap-3 text-[10px] text-titos-gray-400">
+              <span>Top 2 → <span className="text-titos-gold font-semibold">Gold</span></span>
+              <span className="text-titos-gray-600" aria-hidden="true">·</span>
+              <span>Bottom 2 → <span className="text-titos-gray-200 font-semibold">Silver</span></span>
             </div>
           )}
         </div>
@@ -76,13 +83,13 @@ export default function StandingsTable({ pool, standings, selectedTeamId = null 
               <th className="px-1.5 sm:px-2 py-2 text-center" title="Sets won">SW</th>
               <th className="px-1.5 sm:px-2 py-2 text-center hidden sm:table-cell" title="Sets lost">SL</th>
               <th className="px-1.5 sm:px-2 py-2 text-center" title="Match record: wins–losses–ties">Rec</th>
-              <th className="pl-1.5 pr-3 sm:px-2 py-2 text-center" title="Point differential">+/-</th>
+              <th className="px-1.5 sm:px-2 py-2 text-center" title="Point differential">+/-</th>
+              <th className="pl-1.5 pr-3 sm:px-2 py-2 text-right" title="Which bracket this seed advances to">Advances</th>
             </tr>
           </thead>
           <tbody>
             {standings.map((row, i) => {
-              const meta = rankMeta(row.qualifies, i)
-              const Icon = meta.icon
+              const meta = rowAccent(row.qualifies)
               const isYou = selectedTeamId && row.teamId === selectedTeamId
               return (
                 <tr
@@ -96,14 +103,11 @@ export default function StandingsTable({ pool, standings, selectedTeamId = null 
                   )}
                 >
                   <td className={cn('pl-3 pr-1.5 sm:px-3 py-2 font-bold tabular-nums', meta.accent, meta.rankClass)}>
-                    <span className="inline-flex items-center gap-1">
-                      {Icon && <Icon className="w-3.5 h-3.5" aria-hidden="true" />}
-                      {i + 1}
-                    </span>
+                    {i + 1}
                   </td>
-                  <td className="px-2 sm:px-3 py-2 text-titos-white font-medium max-w-[9rem] sm:max-w-none truncate" title={row.name}>
+                  <td className="px-2 sm:px-3 py-2 text-titos-white font-medium max-w-[9rem] sm:max-w-none truncate" title={cleanTeamName(row.name)}>
                     <span className="inline-flex items-center gap-2">
-                      <span className="truncate">{row.name}</span>
+                      <span className="truncate">{cleanTeamName(row.name)}</span>
                       {isYou && (
                         <span className="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded bg-titos-gold text-titos-black text-[9px] font-black uppercase tracking-wider">
                           You
@@ -116,14 +120,17 @@ export default function StandingsTable({ pool, standings, selectedTeamId = null 
                   <td className="px-1.5 sm:px-2 py-2 text-center text-titos-gray-300 tabular-nums whitespace-nowrap">
                     {row.w}<span className="text-titos-gray-600">–</span>{row.l}<span className="text-titos-gray-600">–</span>{row.t ?? 0}
                   </td>
-                  <td className="pl-1.5 pr-3 sm:px-2 py-2 text-center font-bold tabular-nums text-titos-gray-300">
+                  <td className="px-1.5 sm:px-2 py-2 text-center font-bold tabular-nums text-titos-gray-300">
                     {row.diff > 0 ? '+' : ''}{row.diff}
+                  </td>
+                  <td className="pl-1.5 pr-3 sm:px-2 py-2 text-right">
+                    <AdvanceBadge qualifies={row.qualifies} />
                   </td>
                 </tr>
               )
             })}
             {standings.length === 0 && (
-              <tr><td colSpan={6} className="px-3 py-4 text-center text-titos-gray-500">No standings yet.</td></tr>
+              <tr><td colSpan={7} className="px-3 py-4 text-center text-titos-gray-500">No standings yet.</td></tr>
             )}
           </tbody>
         </table>

--- a/components/tournament/TeamPicker.js
+++ b/components/tournament/TeamPicker.js
@@ -7,6 +7,7 @@
 
 import { useEffect, useState } from 'react'
 import { Users } from 'lucide-react'
+import { cleanTeamName } from '@/lib/tournament/displayName'
 
 const STORAGE_KEY_PREFIX = 'titos:tourney-team:'
 
@@ -57,7 +58,7 @@ export default function TeamPicker({ slug, pools = [], value, onChange }) {
                 .sort((a, b) => (a.seed ?? 99) - (b.seed ?? 99))
                 .map((t) => (
                   <option key={t.id} value={t.id}>
-                    {t.seed ? `${t.seed}. ` : ''}{t.name}
+                    {t.seed ? `${t.seed}. ` : ''}{cleanTeamName(t.name)}
                   </option>
                 ))}
             </optgroup>

--- a/components/tournament/TeamSchedule.js
+++ b/components/tournament/TeamSchedule.js
@@ -16,6 +16,7 @@ import { MapPin, Clock, Mic } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { refAssignmentForMatch } from '@/lib/tournament/refRotation'
 import { tallySetsWon } from '@/lib/tournament/computeMatchStatus'
+import { cleanTeamName } from '@/lib/tournament/displayName'
 
 function fmtTime(date) {
   if (!date) return '—'
@@ -109,13 +110,13 @@ export default function TeamSchedule({ team, pool }) {
   return (
     <section
       className="mb-8 card-flat rounded-2xl overflow-hidden border border-titos-gold/30"
-      aria-label={`Schedule for ${team.name}`}
+      aria-label={`Schedule for ${cleanTeamName(team.name)}`}
     >
       <header className="px-5 py-3 bg-titos-gold/10 border-b border-titos-gold/20 flex items-baseline justify-between gap-3 flex-wrap">
         <div>
           <p className="text-[10px] font-bold uppercase tracking-wider text-titos-gold">Your team</p>
           <h2 className="font-display text-xl font-black text-titos-white leading-tight">
-            {team.name}
+            {cleanTeamName(team.name)}
           </h2>
         </div>
         <div className="text-[11px] text-titos-gray-400">
@@ -133,9 +134,9 @@ export default function TeamSchedule({ team, pool }) {
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
             <span className="text-titos-white text-base font-semibold">
               vs{' '}
-              {nextMatch.homeTeamId === teamId
-                ? nextMatch.awayTeam?.name || 'TBD'
-                : nextMatch.homeTeam?.name || 'TBD'}
+              {(nextMatch.homeTeamId === teamId
+                ? cleanTeamName(nextMatch.awayTeam?.name)
+                : cleanTeamName(nextMatch.homeTeam?.name)) || 'TBD'}
             </span>
             <span className="inline-flex items-center gap-1 text-sm text-titos-gray-300">
               <Clock className="w-3.5 h-3.5" aria-hidden="true" />
@@ -158,9 +159,9 @@ export default function TeamSchedule({ team, pool }) {
           <ul className="space-y-2.5">
             {myMatches.map((m) => {
               const opp =
-                m.homeTeamId === teamId
-                  ? m.awayTeam?.name || 'TBD'
-                  : m.homeTeam?.name || 'TBD'
+                (m.homeTeamId === teamId
+                  ? cleanTeamName(m.awayTeam?.name)
+                  : cleanTeamName(m.homeTeam?.name)) || 'TBD'
               const result = computeResultText(m, teamId)
               const setsText = setSummary(m)
               const isLive = m.status === 'live'
@@ -229,9 +230,9 @@ export default function TeamSchedule({ team, pool }) {
                   </span>
                 </div>
                 <div className="text-sm text-titos-white font-medium truncate">
-                  {m.homeTeam?.name || 'TBD'}{' '}
+                  {cleanTeamName(m.homeTeam?.name) || 'TBD'}{' '}
                   <span className="text-titos-gray-500">vs</span>{' '}
-                  {m.awayTeam?.name || 'TBD'}
+                  {cleanTeamName(m.awayTeam?.name) || 'TBD'}
                 </div>
               </li>
             ))}

--- a/lib/server/tournaments.js
+++ b/lib/server/tournaments.js
@@ -124,6 +124,23 @@ export function getTournamentHub(slug) {
                 include: {
                   homeTeam: { select: { id: true, name: true } },
                   awayTeam: { select: { id: true, name: true } },
+                  refTeam: { select: { id: true, name: true } },
+                  scores: { orderBy: { setNumber: 'asc' } },
+                },
+              },
+            },
+          },
+          // Brackets are rendered inline on the hub once generated — so
+          // pull them with the same shape the standalone bracket page uses.
+          brackets: {
+            orderBy: { division: 'asc' },
+            include: {
+              matches: {
+                orderBy: [{ bracketRound: 'asc' }, { bracketPosition: 'asc' }],
+                include: {
+                  homeTeam: { select: { id: true, name: true } },
+                  awayTeam: { select: { id: true, name: true } },
+                  refTeam: { select: { id: true, name: true } },
                   scores: { orderBy: { setNumber: 'asc' } },
                 },
               },
@@ -158,6 +175,7 @@ export function getTournamentHub(slug) {
         imageUrl: findTournamentImage(t.slug),
         tournamentTeams: t.tournamentTeams,
         pools: poolsWithStandings,
+        brackets: t.brackets,
         liveMatch,
       }
     },
@@ -186,6 +204,7 @@ export function getTournamentBracket(slug) {
                 include: {
                   homeTeam: { select: { id: true, name: true } },
                   awayTeam: { select: { id: true, name: true } },
+                  refTeam: { select: { id: true, name: true } },
                   scores: { orderBy: { setNumber: 'asc' } },
                 },
               },

--- a/lib/tournament/advanceBracketWinner.js
+++ b/lib/tournament/advanceBracketWinner.js
@@ -1,23 +1,61 @@
 import prismaClient from '@/lib/prisma'
 import { MATCH_STATUS } from './constants'
+import { findNextOnSameCourt } from './canonicalBracketSchedule'
 
 /**
- * When a bracket match finalizes, write its winner into the next round's
- * empty slot via the nextMatchId chain.
+ * When a bracket match finalizes:
+ *   1. Write the winner into the next round's empty slot via nextMatchId.
+ *   2. Assign the LOSER as ref of the next match scheduled on the same
+ *      court (per the April 25 Captains Package rotation — loser of the
+ *      1:00 PM match refs the 1:45 PM match on that court, and so on).
  *
- * Idempotent — safe to call multiple times for the same match; it only
- * writes if the slot is empty. If both feeder matches are complete, both
- * slots get populated.
+ * Idempotent on both counts — skips slots that are already populated, so
+ * calling this multiple times for the same match is safe.
  */
 export async function advanceBracketWinner(bracketMatchId, prisma = prismaClient) {
   const match = await prisma.tournamentMatch.findUnique({
     where: { id: bracketMatchId },
-    select: { id: true, winnerId: true, status: true, nextMatchId: true },
+    select: {
+      id: true,
+      winnerId: true,
+      status: true,
+      nextMatchId: true,
+      bracketId: true,
+      courtNumber: true,
+      scheduledTime: true,
+      homeTeamId: true,
+      awayTeamId: true,
+    },
   })
   if (!match) return { advanced: false, reason: 'match not found' }
   if (match.status !== MATCH_STATUS.FINAL) return { advanced: false, reason: 'not final' }
   if (!match.winnerId) return { advanced: false, reason: 'no winner set' }
-  if (!match.nextMatchId) return { advanced: false, reason: 'no downstream match (final round)' }
+
+  // ── Ref rotation: loser of this match refs the next match on same court.
+  // Computed independently of nextMatchId (SF/F still need a ref even
+  // when no downstream match is wired for a given team).
+  const loserId =
+    match.homeTeamId && match.homeTeamId !== match.winnerId
+      ? match.homeTeamId
+      : match.awayTeamId && match.awayTeamId !== match.winnerId
+        ? match.awayTeamId
+        : null
+  let refAssigned = false
+  if (loserId) {
+    const nextOnCourt = await findNextOnSameCourt(prisma, match)
+    if (nextOnCourt && !nextOnCourt.refTeamId) {
+      await prisma.tournamentMatch.update({
+        where: { id: nextOnCourt.id },
+        data: { refTeamId: loserId },
+      })
+      refAssigned = true
+    }
+  }
+
+  // ── Winner advancement: write into downstream slot.
+  if (!match.nextMatchId) {
+    return { advanced: false, reason: 'no downstream match (final round)', refAssigned }
+  }
 
   const next = await prisma.tournamentMatch.findUnique({
     where: { id: match.nextMatchId },
@@ -25,7 +63,7 @@ export async function advanceBracketWinner(bracketMatchId, prisma = prismaClient
       feederMatches: { select: { id: true, gameOrder: true, bracketPosition: true } },
     },
   })
-  if (!next) return { advanced: false, reason: 'next match missing' }
+  if (!next) return { advanced: false, reason: 'next match missing', refAssigned }
 
   // Determine which slot (homeTeamId or awayTeamId) this winner fills.
   // Convention: the feeder with the LOWER bracket slot fills team A,
@@ -40,8 +78,8 @@ export async function advanceBracketWinner(bracketMatchId, prisma = prismaClient
     : { awayTeamId: match.winnerId }
   // Only write if the slot is empty — avoids overwriting on retries
   const canOverwrite = isA ? !next.homeTeamId : !next.awayTeamId
-  if (!canOverwrite) return { advanced: false, reason: 'slot already filled' }
+  if (!canOverwrite) return { advanced: false, reason: 'slot already filled', refAssigned }
 
   await prisma.tournamentMatch.update({ where: { id: next.id }, data })
-  return { advanced: true, nextMatchId: next.id }
+  return { advanced: true, nextMatchId: next.id, refAssigned }
 }

--- a/lib/tournament/canStartBrackets.js
+++ b/lib/tournament/canStartBrackets.js
@@ -2,14 +2,19 @@ import prismaClient from '@/lib/prisma'
 import { MATCH_STATUS } from './constants'
 
 /**
- * Returns `true` when every pool match in the tournament is FINAL (completed)
- * with a winner set. Used to gate the admin "Generate Brackets" button.
+ * Returns `true` when every pool match in the tournament is FINAL (completed).
+ * Used to gate the admin "Generate Brackets" button.
+ *
+ * IMPORTANT: pool matches are 2 fixed sets (captain's package), so a 1-1
+ * split is a valid FINAL result with winnerId = null — each team gets credit
+ * for their set in pool standings but no overall match winner. Do NOT add a
+ * `winnerId != null` check here; that rejects legitimate pool splits and
+ * makes it impossible to generate brackets.
  *
  * Returns `false` if:
  *   - The tournament has no pools
  *   - Any pool has no matches
  *   - Any pool match is SCHEDULED or LIVE
- *   - Any FINAL match lacks a winnerId (data-integrity guard)
  */
 export async function canStartBrackets(tournamentId, prisma = prismaClient) {
   if (!tournamentId) return false
@@ -17,7 +22,7 @@ export async function canStartBrackets(tournamentId, prisma = prismaClient) {
     where: { tournamentId },
     select: {
       id: true,
-      matches: { select: { id: true, status: true, winnerId: true } },
+      matches: { select: { id: true, status: true } },
     },
   })
   if (!pools.length) return false
@@ -26,8 +31,60 @@ export async function canStartBrackets(tournamentId, prisma = prismaClient) {
     if (!pool.matches.length) return false
     for (const m of pool.matches) {
       if (m.status !== MATCH_STATUS.FINAL) return false
-      if (!m.winnerId) return false
     }
   }
   return true
+}
+
+/**
+ * Detailed variant used by the admin UI to produce actionable error messages.
+ * Returns { ok, reason, pending } — `pending` lists the match IDs + pool name
+ * + status that are blocking bracket generation, so the admin sees exactly
+ * which matches still need scores instead of a generic "not ready" string.
+ */
+export async function diagnoseBracketReadiness(tournamentId, prisma = prismaClient) {
+  if (!tournamentId) return { ok: false, reason: 'No tournament id' }
+  const pools = await prisma.tournamentPool.findMany({
+    where: { tournamentId },
+    orderBy: { name: 'asc' },
+    select: {
+      id: true,
+      name: true,
+      matches: {
+        select: {
+          id: true,
+          status: true,
+          homeTeam: { select: { name: true } },
+          awayTeam: { select: { name: true } },
+        },
+      },
+    },
+  })
+  if (!pools.length) return { ok: false, reason: 'No pools generated yet' }
+
+  const pending = []
+  for (const pool of pools) {
+    if (!pool.matches.length) {
+      return { ok: false, reason: `Pool ${pool.name} has no matches. Generate the schedule first.` }
+    }
+    for (const m of pool.matches) {
+      if (m.status !== MATCH_STATUS.FINAL) {
+        pending.push({
+          id: m.id,
+          pool: pool.name,
+          status: m.status,
+          label: `${m.homeTeam?.name ?? '?'} vs ${m.awayTeam?.name ?? '?'}`,
+        })
+      }
+    }
+  }
+
+  if (pending.length > 0) {
+    return {
+      ok: false,
+      reason: `${pending.length} pool match${pending.length === 1 ? '' : 'es'} still pending`,
+      pending,
+    }
+  }
+  return { ok: true }
 }

--- a/lib/tournament/canonicalBracketSchedule.js
+++ b/lib/tournament/canonicalBracketSchedule.js
@@ -1,0 +1,127 @@
+// Bracket schedule (courts + scheduled times + initial refs) per the April 25
+// Captains Package PDF. Pool play uses rounds 1..N on courts 1..4 at 30-min
+// intervals starting at tournament.date. Bracket play picks up 3 hours after
+// kickoff and runs on a fixed 45-min cadence:
+//
+//   QF slot 1 = kickoff + 180 min  (1:00 PM for a 10:00 AM kickoff)
+//   QF slot 2 = kickoff + 225 min  (1:45 PM)
+//   SF       = kickoff + 270 min  (2:30 PM)
+//   F        = kickoff + 315 min  (3:15 PM)
+//
+// Court allocation (from the PDF):
+//   Gold bracket   → Courts 1 + 2
+//   Silver bracket → Courts 3 + 4
+//
+// Court sequence per court (time-ordered) drives the ref-rotation chain:
+// the loser of match[i] on court X refs match[i+1] on court X. Everything
+// below that first QF is derived at finalize-time (advanceBracketWinner);
+// here we stamp the deterministic bits only.
+//
+// Court sequence for a standard 8-QF bracket:
+//   Court 1: QF0 (1:00) → QF2 (1:45) → SF0 (2:30) → F (3:15)   [Gold]
+//   Court 2: QF1 (1:00) → QF3 (1:45) → SF1 (2:30)              [Gold]
+//   Court 3: QF0 (1:00) → QF2 (1:45) → SF0 (2:30) → F (3:15)   [Silver]
+//   Court 4: QF1 (1:00) → QF3 (1:45) → SF1 (2:30)              [Silver]
+//
+// The first QF on each court (QF0/QF1) is reffed at generation time by the
+// HOME team of the next QF on that court (a team that's idle at 1:00 PM
+// because its pool's top half plays the later slot). Every later slot's ref
+// is a "loser of previous match on this court" — filled in downstream by
+// advanceBracketWinner as each match finalizes.
+
+import { BRACKET_ROUND, DIVISION_GOLD } from './constants'
+
+export const BRACKET_START_OFFSET_MINUTES = 180 // kickoff → first QF
+export const BRACKET_SLOT_INTERVAL_MINUTES = 45  // QF1 → QF2 → SF → F
+
+/**
+ * Court assignment for a bracket match.
+ *   Gold:   positions 0,2 → Court 1  |  positions 1,3 → Court 2
+ *   Silver: positions 0,2 → Court 3  |  positions 1,3 → Court 4
+ *
+ * SF follows the same mapping (SF0 takes the same court as QF0/QF2; SF1
+ * takes QF1/QF3's court). The Final always lands on the lower court.
+ */
+export function courtFor({ division, bracketRound, bracketPosition }) {
+  const goldOffset = division === DIVISION_GOLD ? 1 : 3
+  if (bracketRound === BRACKET_ROUND.FINAL) return goldOffset
+  // QF/SF: even positions → lower court, odd → upper court
+  return goldOffset + (bracketPosition % 2)
+}
+
+/**
+ * Minute offset from kickoff for a given bracket match slot.
+ * Returns null if the round isn't recognized (safe no-op for admins to
+ * populate manually).
+ */
+export function minuteOffsetFor({ bracketRound, bracketPosition }) {
+  if (bracketRound === BRACKET_ROUND.QUARTERFINAL) {
+    // QF positions 0,1 are the 1:00 slot; positions 2,3 are the 1:45 slot.
+    const slot = bracketPosition >= 2 ? 1 : 0
+    return BRACKET_START_OFFSET_MINUTES + slot * BRACKET_SLOT_INTERVAL_MINUTES
+  }
+  if (bracketRound === BRACKET_ROUND.SEMIFINAL) {
+    return BRACKET_START_OFFSET_MINUTES + 2 * BRACKET_SLOT_INTERVAL_MINUTES
+  }
+  if (bracketRound === BRACKET_ROUND.FINAL) {
+    return BRACKET_START_OFFSET_MINUTES + 3 * BRACKET_SLOT_INTERVAL_MINUTES
+  }
+  return null
+}
+
+/**
+ * Resolve the scheduled Date for a match given the tournament kickoff.
+ * Returns null if either the kickoff or the round mapping is missing.
+ */
+export function scheduledTimeFor({ kickoff, bracketRound, bracketPosition }) {
+  if (!kickoff) return null
+  const offset = minuteOffsetFor({ bracketRound, bracketPosition })
+  if (offset == null) return null
+  const d = new Date(kickoff)
+  d.setMinutes(d.getMinutes() + offset)
+  return d
+}
+
+/**
+ * Determine the initial ref team for the two "1:00 PM" QFs.
+ *
+ * Rule: the ref of QF at position P on court X is the HOME team of the
+ * QF at position P+2 on the same court (guaranteed idle at 1:00 PM since
+ * their match kicks off at 1:45). If no such match exists (e.g. a 4-QF
+ * bracket where positions 2,3 don't exist), returns null.
+ *
+ * @param {object} match - the QF being reffed (needs bracketPosition)
+ * @param {Array<object>} siblings - all QF matches in the same bracket
+ * @returns {string|null} teamId to use as refTeam, or null
+ */
+export function initialQfRef(match, siblings) {
+  if (match.bracketRound !== BRACKET_ROUND.QUARTERFINAL) return null
+  // Only the 1:00 PM slot (positions 0,1) gets a generation-time ref.
+  if (match.bracketPosition >= 2) return null
+  const nextPos = match.bracketPosition + 2
+  const laterSameCourt = siblings.find(
+    (s) =>
+      s.bracketRound === BRACKET_ROUND.QUARTERFINAL &&
+      s.bracketPosition === nextPos,
+  )
+  return laterSameCourt?.homeTeamId ?? null
+}
+
+/**
+ * Given a just-finalized bracket match, find the next match on the same
+ * court (by scheduledTime). Used by advanceBracketWinner to assign the
+ * loser as ref downstream. Pure helper — takes prisma explicitly so it's
+ * easy to stub in tests.
+ */
+export async function findNextOnSameCourt(prisma, finalizedMatch) {
+  if (!finalizedMatch?.courtNumber || !finalizedMatch?.scheduledTime) return null
+  return prisma.tournamentMatch.findFirst({
+    where: {
+      bracketId: finalizedMatch.bracketId,
+      courtNumber: finalizedMatch.courtNumber,
+      scheduledTime: { gt: finalizedMatch.scheduledTime },
+    },
+    orderBy: { scheduledTime: 'asc' },
+    select: { id: true, refTeamId: true },
+  })
+}

--- a/lib/tournament/displayName.js
+++ b/lib/tournament/displayName.js
@@ -1,0 +1,28 @@
+// Defensive display helpers for team names.
+//
+// Historically some tournament teams were saved with admin-ism suffixes in
+// their `name` field (e.g. "Adrian · Pool assigned", "Mo · Pool assigned")
+// because admins pasted the admin-page status label into the team-name
+// input when creating the roster. That leaks into every public surface
+// that renders the team name verbatim — bracket cards, match lists, the
+// "Up Next" spotlight, etc.
+//
+// Rather than force a manual rename of every affected row, we strip the
+// known suffix at render time. Going forward, teams with cleanly-typed
+// names (no " · Pool assigned" tail) pass through untouched.
+//
+// Kept as a pure util so every display surface — pool cards, bracket
+// cards, spotlight, ref lines — gets the same treatment consistently.
+
+const POOL_ASSIGNED_SUFFIX = /\s*·\s*Pool\s+assigned\s*$/i
+
+/**
+ * Strip known bookkeeping tails from a team/ref display name.
+ * Returns an empty string unchanged; passes through `null`/`undefined`
+ * so callers can keep their `.name ?? 'TBD'` fallback chains.
+ */
+export function cleanTeamName(name) {
+  if (name == null) return name
+  if (typeof name !== 'string') return name
+  return name.replace(POOL_ASSIGNED_SUFFIX, '').trim()
+}

--- a/lib/tournament/generateBracketSeeding.js
+++ b/lib/tournament/generateBracketSeeding.js
@@ -1,23 +1,31 @@
 // Bracket seeding with cross-pool matchups.
 //
 // Per April 25 Tournament Captains Package: pools are paired A↔B and C↔D
-// (NOT a rotational N/2 shift). For 4 pools, Gold and Silver brackets each
-// have 4 QF matches:
+// (NOT a rotational N/2 shift), and the two matchups per pair are
+// INTERLEAVED across courts so the 1:00 PM slot runs on all four courts
+// simultaneously, then the 1:45 PM slot plays the "rematch" half:
 //
-//   GOLD (top 2 from each pool):
-//     QF1: A1 vs B2
-//     QF2: B1 vs A2
-//     QF3: C1 vs D2
-//     QF4: D1 vs C2
+//   GOLD (top 2 from each pool) — position → (court, time):
+//     pos 0: A1 v B2    → C1 @ 1:00 PM
+//     pos 1: C1 v D2    → C2 @ 1:00 PM
+//     pos 2: A2 v B1    → C1 @ 1:45 PM
+//     pos 3: C2 v D1    → C2 @ 1:45 PM
 //
 //   SILVER (bottom 2 from each pool):
-//     QF1: A3 vs B4
-//     QF2: B3 vs A4
-//     QF3: C3 vs D4
-//     QF4: D3 vs C4
+//     pos 0: A3 v B4    → C3 @ 1:00 PM
+//     pos 1: C3 v D4    → C4 @ 1:00 PM
+//     pos 2: A4 v B3    → C3 @ 1:45 PM
+//     pos 3: C4 v D3    → C4 @ 1:45 PM
 //
-// SF mapping: QF1/QF2 → SF1, QF3/QF4 → SF2 (keeps the A/B region separate
-// from the C/D region until the final).
+// SF mapping (wired in the admin route, not here): same-court QFs feed the
+// same SF, so QF0 & QF2 (both Court 1) → SF0; QF1 & QF3 (both Court 2) → SF1.
+// Both SFs then feed the Final, which plays on Court 1 (Gold) or Court 3
+// (Silver).
+//
+// Home/away orientation mirrors the PDF exactly: for the 1:00 PM matchups
+// the higher seed is home (A1 v B2); for the 1:45 PM "rematch" slot the
+// lower-pair seed is home (A2 v B1) — preserving the PDF's left/right
+// column so refs printed next to each match line up.
 //
 // For pool counts ≠ 4 we fall back to a generic "pair adjacent pools"
 // algorithm (pools 0↔1, 2↔3, …). Odd pool counts leave the last pool
@@ -63,15 +71,20 @@ export function generateBracketSeeding(pools, division) {
   if (N % 2 === 0) {
     // Even pool count — pair adjacent pools (0↔1), (2↔3), (4↔5), ...
     // Matches the captain's-package spec for 4 pools (A↔B, C↔D).
-    for (let i = 0; i < N - 1; i += 2) {
-      const poolA = pools[i]
-      const poolB = pools[i + 1]
+    //
+    // INTERLEAVED emission: we do TWO passes over the pool-pairs so all of
+    // the "1:00 PM" matchups (one per pair) come out before any "1:45 PM"
+    // matchups. Position indices land on courts via `position % 2` (see
+    // canonicalBracketSchedule.courtFor), and positions <2 are the 1:00 PM
+    // slot while positions ≥2 are the 1:45 PM slot — so interleaving here
+    // is what makes Court 1 and Court 2 each run two QFs in sequence.
+    const pairs = []
+    for (let i = 0; i < N - 1; i += 2) pairs.push([pools[i], pools[i + 1]])
 
+    // Pass 1 (1:00 PM slot): poolA top seed vs poolB second seed.
+    for (const [poolA, poolB] of pairs) {
       const a1 = poolA.standings[seedIdx(poolA, 1)]
       const b2 = poolB.standings[seedIdx(poolB, 2)]
-      const b1 = poolB.standings[seedIdx(poolB, 1)]
-      const a2 = poolA.standings[seedIdx(poolA, 2)]
-
       if (a1?.teamId && b2?.teamId) {
         matches.push({
           slot: slot++,
@@ -82,14 +95,22 @@ export function generateBracketSeeding(pools, division) {
           teamBSeedLabel: `${poolB.label}${seedRank(poolB, 2)}`,
         })
       }
-      if (b1?.teamId && a2?.teamId) {
+    }
+
+    // Pass 2 (1:45 PM slot): poolA's 2nd seed vs poolB's top seed.
+    // Home/away follows the PDF — poolA's lower seed is listed first, so
+    // it lands as teamA (home) and poolB's top seed is teamB (away).
+    for (const [poolA, poolB] of pairs) {
+      const a2 = poolA.standings[seedIdx(poolA, 2)]
+      const b1 = poolB.standings[seedIdx(poolB, 1)]
+      if (a2?.teamId && b1?.teamId) {
         matches.push({
           slot: slot++,
           round: BRACKET_ROUND.QUARTERFINAL,
-          teamAId: b1.teamId,
-          teamBId: a2.teamId,
-          teamASeedLabel: `${poolB.label}${seedRank(poolB, 1)}`,
-          teamBSeedLabel: `${poolA.label}${seedRank(poolA, 2)}`,
+          teamAId: a2.teamId,
+          teamBId: b1.teamId,
+          teamASeedLabel: `${poolA.label}${seedRank(poolA, 2)}`,
+          teamBSeedLabel: `${poolB.label}${seedRank(poolB, 1)}`,
         })
       }
     }

--- a/prisma/migrations/20260424_tournament_ref_team/migration.sql
+++ b/prisma/migrations/20260424_tournament_ref_team/migration.sql
@@ -1,0 +1,25 @@
+-- Migration: tournament_ref_team (2026-04-24)
+-- Adds refTeamId to TournamentMatch so admins can explicitly assign a team to
+-- whistle each match. Pool matches keep the canonical PDF rotation as a
+-- fallback when refTeamId is null; bracket matches had no ref-display
+-- mechanism before this field.
+-- Additive and idempotent — safe to run twice.
+
+ALTER TABLE "TournamentMatch" ADD COLUMN IF NOT EXISTS "refTeamId" TEXT;
+
+-- SetNull so deleting a team doesn't cascade-wipe the match. The match row
+-- keeps its other data and just loses its ref assignment.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'TournamentMatch_refTeamId_fkey'
+  ) THEN
+    ALTER TABLE "TournamentMatch"
+      ADD CONSTRAINT "TournamentMatch_refTeamId_fkey"
+      FOREIGN KEY ("refTeamId") REFERENCES "TournamentTeam"("id")
+      ON DELETE SET NULL ON UPDATE NO ACTION;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "TournamentMatch_refTeamId_idx" ON "TournamentMatch"("refTeamId");
+
+ANALYZE "TournamentMatch";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -208,6 +208,7 @@ model TournamentTeam {
   seed         Int?
   homeMatches  TournamentMatch[] @relation("TournHomeTeam")
   awayMatches  TournamentMatch[] @relation("TournAwayTeam")
+  refMatches   TournamentMatch[] @relation("TournRefTeam")
 
   @@index([tournamentId])
   @@index([poolId])
@@ -248,6 +249,8 @@ model TournamentMatch {
   awaySeedLabel   String?
   courtNumber     Int?
   scheduledTime   DateTime?
+  refTeamId       String?              // team on the whistle — manual override. Pool matches fall back to the canonical PDF rotation (refRotation.js) when null.
+  refTeam         TournamentTeam?      @relation("TournRefTeam", fields: [refTeamId], references: [id], onDelete: SetNull, onUpdate: NoAction)
   status          String               @default("scheduled")
   winnerId        String?              // TournamentTeam id once decided
   roundNumber     Int?                 // pool: round of round-robin; bracket: unused
@@ -264,6 +267,7 @@ model TournamentMatch {
   @@index([homeTeamId])
   @@index([awayTeamId])
   @@index([nextMatchId])
+  @@index([refTeamId])
   @@index([status])
 }
 

--- a/tests/unit/tournament/generateBracketSeeding.test.js
+++ b/tests/unit/tournament/generateBracketSeeding.test.js
@@ -21,51 +21,62 @@ describe('generateBracketSeeding — 4 pools / Gold bracket', () => {
     expect(matches.every(m => m.round === 1)).toBe(true)
   })
 
-  it('pairs top seeds with second seeds from a different pool', () => {
+  it('matches the Captains Package schedule (position → matchup)', () => {
+    // Per PDF: the two 1:00 PM QFs come first (positions 0,1 — Courts 1 & 2),
+    // then the two 1:45 PM "rematch" QFs (positions 2,3 — Courts 1 & 2).
+    // Home/away preserves the PDF's left-to-right column order.
     const matches = generateBracketSeeding(pools, DIVISION_GOLD)
-    // All matches must cross pools — verify no first-round rematch of pool opponents
+    expect(matches[0]).toMatchObject({ teamASeedLabel: 'A1', teamBSeedLabel: 'B2' })
+    expect(matches[1]).toMatchObject({ teamASeedLabel: 'C1', teamBSeedLabel: 'D2' })
+    expect(matches[2]).toMatchObject({ teamASeedLabel: 'A2', teamBSeedLabel: 'B1' })
+    expect(matches[3]).toMatchObject({ teamASeedLabel: 'C2', teamBSeedLabel: 'D1' })
+  })
+
+  it('never rematches pool opponents in round 1', () => {
+    const matches = generateBracketSeeding(pools, DIVISION_GOLD)
     for (const m of matches) {
-      const poolA = m.teamASeedLabel[0]
-      const poolB = m.teamBSeedLabel[0]
-      expect(poolA).not.toBe(poolB)
+      expect(m.teamASeedLabel[0]).not.toBe(m.teamBSeedLabel[0])
     }
   })
 
-  it('uses rank-1 and rank-2 seeds (Gold)', () => {
+  it('only uses rank-1 and rank-2 seeds (Gold)', () => {
     const matches = generateBracketSeeding(pools, DIVISION_GOLD)
-    // A-side must always be "<pool>1", B-side must always be "<pool>2"
     for (const m of matches) {
-      expect(m.teamASeedLabel).toMatch(/^[A-D]1$/)
-      expect(m.teamBSeedLabel).toMatch(/^[A-D]2$/)
+      expect(m.teamASeedLabel).toMatch(/^[A-D][12]$/)
+      expect(m.teamBSeedLabel).toMatch(/^[A-D][12]$/)
     }
   })
 
-  it('includes every pool as a top seed exactly once', () => {
+  it('uses each pool-seed slot (A1..D2) exactly once across all matches', () => {
     const matches = generateBracketSeeding(pools, DIVISION_GOLD)
-    const topSides = matches.map(m => m.teamASeedLabel).sort()
-    expect(topSides).toEqual(['A1', 'B1', 'C1', 'D1'])
-  })
-
-  it('includes every pool as a second seed exactly once', () => {
-    const matches = generateBracketSeeding(pools, DIVISION_GOLD)
-    const secondSides = matches.map(m => m.teamBSeedLabel).sort()
-    expect(secondSides).toEqual(['A2', 'B2', 'C2', 'D2'])
+    const allSeeds = matches.flatMap(m => [m.teamASeedLabel, m.teamBSeedLabel]).sort()
+    expect(allSeeds).toEqual(['A1', 'A2', 'B1', 'B2', 'C1', 'C2', 'D1', 'D2'])
   })
 })
 
 describe('generateBracketSeeding — 4 pools / Silver bracket', () => {
   const pools = [poolWith('A'), poolWith('B'), poolWith('C'), poolWith('D')]
 
-  it('uses rank-3 and rank-4 seeds', () => {
+  it('matches the Captains Package schedule (position → matchup)', () => {
+    // Silver mirrors Gold but with the pool's bottom two seeds (rank-3 home
+    // vs rank-4 away at 1:00 PM; rank-4 home vs rank-3 away at 1:45 PM).
     const matches = generateBracketSeeding(pools, DIVISION_SILVER)
     expect(matches).toHaveLength(4)
+    expect(matches[0]).toMatchObject({ teamASeedLabel: 'A3', teamBSeedLabel: 'B4' })
+    expect(matches[1]).toMatchObject({ teamASeedLabel: 'C3', teamBSeedLabel: 'D4' })
+    expect(matches[2]).toMatchObject({ teamASeedLabel: 'A4', teamBSeedLabel: 'B3' })
+    expect(matches[3]).toMatchObject({ teamASeedLabel: 'C4', teamBSeedLabel: 'D3' })
+  })
+
+  it('only uses rank-3 and rank-4 seeds (Silver)', () => {
+    const matches = generateBracketSeeding(pools, DIVISION_SILVER)
     for (const m of matches) {
-      expect(m.teamASeedLabel).toMatch(/^[A-D]3$/)
-      expect(m.teamBSeedLabel).toMatch(/^[A-D]4$/)
+      expect(m.teamASeedLabel).toMatch(/^[A-D][34]$/)
+      expect(m.teamBSeedLabel).toMatch(/^[A-D][34]$/)
     }
   })
 
-  it('silver matches also cross pools (no first-round rematches)', () => {
+  it('never rematches pool opponents in round 1', () => {
     const matches = generateBracketSeeding(pools, DIVISION_SILVER)
     for (const m of matches) {
       expect(m.teamASeedLabel[0]).not.toBe(m.teamBSeedLabel[0])


### PR DESCRIPTION
…signments

Makes the tournament flow match the April 25 Captains Package PDF end-to-end and fixes the admin surfaces players + event staff actually use on match day.

Schema
- Add TournamentMatch.refTeamId (nullable, FK to TournamentTeam, SetNull on team delete). Lets admins explicitly assign a whistle team per bracket match; pool matches keep the canonical PDF rotation as fallback.

Bracket generation + schedule
- Rewrite QF seeding so pairs interleave across two passes instead of bunching by pool (A1vB2, C1vD2, A2vB1, C2vD1) — matches the PDF order and the court/time pairing used by canonicalBracketSchedule.
- Fix SF feeder chain: QFs wire to SFs via position % sfCount so visually-adjacent QFs actually feed the same SF.
- New canonicalBracketSchedule helper maps bracket position → court + scheduled time, applied at bracket-generation time.
- DELETE brackets now cascade-wipes set scores, nulls nextMatchId, and drops matches/brackets in a single transaction — no more "can't delete because scores exist" dead end.

Admin UX
- Unified admin bracket scoring card: identity strip (status + teams) → court/ref editors → collapsible score entry, all inside one border.
- Default-collapse every match except LIVE — cuts page scroll from ~8000px to ~1800px on a 14-match bracket.
- 2-column grid at md+ so QFs render 2x2 instead of 4 stacked.
- New BracketMatchMeta component for inline court + ref editing.
- Drop per-set keyboard tip (repeated 42x per page for no gain).
- New reset-scores admin route for nuking a tournament's scores without deleting structure.

Public UX
- cleanTeamName() helper strips "· Pool assigned" junk from dirty DB names; applied across every public component (StandingsTable, TeamPicker, TeamSchedule, LiveMatchCard, MatchCard, BracketTree, hub Up Next / champion callouts).
- Up Next spotlight now shows ALL concurrent matches (two QFs on different courts at the same time) instead of just the first.
- Bracket MatchCard drops time to prevent "1:00 PM" truncating to "1"; drops S1/S2/S3 headers that crowded the cramped bracket cells.
- BracketTree regroups QFs by SF feeder (visually adjacent pairs feed the same SF) instead of sequential position.

Tests
- Seeding tests updated to assert interleaved QF order + SF wiring.
- 87/87 unit tests pass.

Migration is additive + idempotent — safe to run ahead of the code deploy.