### PR TITLE
feat(admin): per-tier court editor + bracket score UX

### DIFF
--- a/app/admin/courts/page.js
+++ b/app/admin/courts/page.js
@@ -1,0 +1,211 @@
+'use client'
+
+// Admin: edit tier → court mappings per league/season.
+// Updating a tier's court number also rewrites the courtNumber on all
+// matches scheduled for upcoming weeks so the public schedule reflects
+// the change immediately. Completed weeks stay historical.
+
+import { useState, useEffect, useCallback } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, Loader2, Save, Check, Trash2, Shield } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+function AuthGate({ onAuth }) {
+  const [pw, setPw] = useState('')
+  const [err, setErr] = useState('')
+  const [checking, setChecking] = useState(false)
+  const submit = async (e) => {
+    e.preventDefault()
+    setChecking(true)
+    setErr('')
+    try {
+      const res = await fetch('/api/admin/auth', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: pw }),
+      })
+      if (res.ok) { sessionStorage.setItem('admin_auth', 'true'); onAuth() }
+      else setErr('Invalid password')
+    } catch { setErr('Connection error') }
+    setChecking(false)
+  }
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="card rounded-xl p-8 w-full max-w-sm">
+        <div className="text-center mb-6">
+          <Shield className="w-10 h-10 text-titos-gold mx-auto mb-3" />
+          <h1 className="font-display text-2xl font-black text-titos-white">Admin Access</h1>
+        </div>
+        <form onSubmit={submit} className="space-y-4">
+          <input type="password" value={pw} onChange={e => setPw(e.target.value)} placeholder="Password" autoFocus
+            className="w-full px-4 py-3 bg-titos-elevated border border-titos-border rounded-lg text-titos-white placeholder-titos-gray-500 focus:outline-none focus:border-titos-gold/50" />
+          {err && <p className="text-status-live text-sm text-center">{err}</p>}
+          <button type="submit" disabled={checking} className="w-full btn-primary justify-center">
+            {checking ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Sign In'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+function TierRow({ tier, onSaved }) {
+  const [court, setCourt] = useState(String(tier.courtNumber))
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [msg, setMsg] = useState('')
+  const [err, setErr] = useState('')
+
+  const dirty = String(tier.courtNumber) !== court.trim() && court.trim() !== ''
+
+  const save = async () => {
+    const ct = parseInt(court, 10)
+    if (!Number.isFinite(ct)) { setErr('Enter a number'); return }
+    setSaving(true); setErr(''); setMsg('')
+    try {
+      const res = await fetch('/api/admin/seasons', {
+        method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'update-tier-court', tierId: tier.id, courtNumber: ct }),
+      })
+      const data = await res.json()
+      if (!res.ok) setErr(data.error || 'Failed')
+      else {
+        setMsg(`Saved (${data.matchesUpdated} upcoming match${data.matchesUpdated === 1 ? '' : 'es'} updated)`)
+        onSaved?.()
+      }
+    } catch { setErr('Network error') }
+    setSaving(false)
+  }
+
+  const remove = async () => {
+    if (!confirm(`Delete Tier ${tier.tierNumber}? Only works if it has no placements or matches.`)) return
+    setDeleting(true); setErr(''); setMsg('')
+    try {
+      const res = await fetch('/api/admin/seasons', {
+        method: 'DELETE', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'delete-tier', tierId: tier.id }),
+      })
+      const data = await res.json()
+      if (!res.ok) setErr(data.error || 'Failed')
+      else { setMsg('Tier deleted'); onSaved?.() }
+    } catch { setErr('Network error') }
+    setDeleting(false)
+  }
+
+  return (
+    <div className="card-flat rounded-xl px-4 py-3 flex flex-wrap items-center gap-3">
+      <div className="min-w-[6rem]">
+        <span className="font-display text-base font-black text-titos-white">Tier {tier.tierNumber}</span>
+        <span className="block text-[11px] text-titos-gray-500 uppercase tracking-wider">{tier.timeSlot}</span>
+      </div>
+      <label className="flex items-center gap-2 text-sm text-titos-gray-300">
+        Court
+        <input
+          type="number"
+          min="1"
+          max="20"
+          value={court}
+          onChange={(e) => setCourt(e.target.value)}
+          className="w-20 px-2 py-1.5 bg-titos-surface border border-titos-border rounded text-center text-titos-white font-bold focus:outline-none focus:border-titos-gold focus:ring-1 focus:ring-titos-gold/30"
+        />
+      </label>
+      <button
+        onClick={save}
+        disabled={!dirty || saving}
+        className={cn('btn-primary text-xs py-2', (!dirty || saving) && 'opacity-50 cursor-not-allowed')}
+      >
+        {saving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Save className="w-3.5 h-3.5" />}
+        Save
+      </button>
+      <button
+        onClick={remove}
+        disabled={deleting}
+        className="text-titos-gray-500 hover:text-status-live transition-colors px-2 py-1.5 text-xs flex items-center gap-1"
+        title="Delete tier (must have no placements or matches)"
+      >
+        {deleting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash2 className="w-3.5 h-3.5" />}
+        Delete
+      </button>
+      <div className="flex-1 min-w-[10rem] text-right">
+        {msg && <span className="text-status-success text-xs flex items-center justify-end gap-1"><Check className="w-3 h-3" />{msg}</span>}
+        {err && <span className="text-status-live text-xs">{err}</span>}
+      </div>
+    </div>
+  )
+}
+
+export default function CourtsAdminPage() {
+  const [authed, setAuthed] = useState(false)
+  const [seasons, setSeasons] = useState([])
+  const [selectedSeasonId, setSelectedSeasonId] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && sessionStorage.getItem('admin_auth') === 'true') setAuthed(true)
+  }, [])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/admin/seasons').then(r => r.json())
+      const list = (res.seasons || []).filter(s => s.status !== 'archived')
+      setSeasons(list)
+      if (list.length && !selectedSeasonId) setSelectedSeasonId(list[0].id)
+    } catch (e) { console.error(e) }
+    setLoading(false)
+  }, [selectedSeasonId])
+
+  useEffect(() => { if (authed) load() }, [authed, load])
+
+  if (!authed) return <AuthGate onAuth={() => setAuthed(true)} />
+
+  const selected = seasons.find(s => s.id === selectedSeasonId)
+  const tiers = (selected?.tiers || []).slice().sort((a, b) => a.tierNumber - b.tierNumber)
+
+  return (
+    <div className="py-12 px-4">
+      <div className="max-w-3xl mx-auto">
+        <div className="flex items-center gap-3 mb-8">
+          <Link href="/admin" className="text-titos-gray-400 hover:text-titos-gold transition-colors">
+            <ArrowLeft className="w-5 h-5" />
+          </Link>
+          <h1 className="font-display text-2xl font-black text-titos-white">Court Assignments</h1>
+        </div>
+
+        <p className="text-titos-gray-400 text-sm mb-6">
+          Edit which court each tier plays on. Saving updates the tier and rewrites the court number on every match scheduled for an upcoming week. Completed weeks are not touched.
+        </p>
+
+        <div className="mb-6">
+          <label className="block text-sm font-medium text-titos-gray-300 mb-2">Season</label>
+          <select
+            value={selectedSeasonId}
+            onChange={(e) => setSelectedSeasonId(e.target.value)}
+            className="w-full px-4 py-3 bg-titos-card border border-titos-border rounded-lg text-titos-white focus:outline-none focus:border-titos-gold/50"
+          >
+            {seasons.map(s => (
+              <option key={s.id} value={s.id}>
+                {s.league?.name} — {s.name} ({s.status})
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {loading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="card-flat rounded-xl h-16 animate-pulse" />
+            ))}
+          </div>
+        ) : tiers.length === 0 ? (
+          <p className="text-titos-gray-500 text-sm">No tiers in this season.</p>
+        ) : (
+          <div className="space-y-3">
+            {tiers.map(t => (
+              <TierRow key={t.id} tier={t} onSaved={load} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/admin/page.js
+++ b/app/admin/page.js
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react'
 import Link from 'next/link'
-import { Shield, Loader2, Save, Check, CheckCircle2, Plus, RefreshCw, AlertTriangle, Calendar, Users, Trophy, FileText, X } from 'lucide-react'
+import { Shield, Loader2, Save, Check, CheckCircle2, Plus, RefreshCw, AlertTriangle, Calendar, Users, Trophy, FileText, X, MapPin } from 'lucide-react'
 import { cn, getSlotInfo } from '@/lib/utils'
 
 const TABS = ['Scores', 'Results', 'Tiers', 'Next Week']
@@ -756,6 +756,7 @@ export default function AdminPage() {
         <div className="mt-10 pt-6 border-t border-titos-border/20 flex flex-wrap justify-center gap-4 text-xs">
           {[
             { label: 'Seasons', href: '/admin/seasons', icon: Calendar },
+            { label: 'Courts', href: '/admin/courts', icon: MapPin },
             { label: 'Registrations', href: '/admin/registrations', icon: Users },
             { label: 'Waivers', href: '/admin/waivers', icon: FileText },
             { label: 'Tournaments', href: '/admin/tournaments', icon: Trophy },

--- a/app/api/admin/seasons/route.js
+++ b/app/api/admin/seasons/route.js
@@ -146,6 +146,37 @@ export async function PATCH(request) {
   try {
     const body = await request.json()
 
+    // Update a single tier's court number. Propagates to existing Match
+    // records ON UPCOMING WEEKS (date >= today) so the schedule view picks
+    // up the new court immediately. Completed weeks keep their historical
+    // court number — that's a record of where the games were actually played.
+    if (body.action === 'update-tier-court') {
+      const { tierId, courtNumber } = body
+      const ct = parseInt(courtNumber, 10)
+      if (!tierId || !Number.isFinite(ct)) {
+        return NextResponse.json({ error: 'tierId and courtNumber required' }, { status: 400 })
+      }
+      const tier = await prisma.tier.findUnique({ where: { id: tierId } })
+      if (!tier) return NextResponse.json({ error: 'Tier not found' }, { status: 404 })
+
+      await prisma.tier.update({ where: { id: tierId }, data: { courtNumber: ct } })
+
+      const today = new Date()
+      today.setHours(0, 0, 0, 0)
+      const upcomingWeeks = await prisma.week.findMany({
+        where: { seasonId: tier.seasonId, date: { gte: today } },
+        select: { id: true },
+      })
+      const result = await prisma.match.updateMany({
+        where: {
+          weekId: { in: upcomingWeeks.map(w => w.id) },
+          tierNumber: tier.tierNumber,
+        },
+        data: { courtNumber: ct },
+      })
+      return NextResponse.json({ success: true, matchesUpdated: result.count })
+    }
+
     // Update team action
     if (body.action === 'update-team') {
       const { teamId, name, captainName, captainEmail } = body
@@ -200,6 +231,28 @@ export async function DELETE(request) {
 
     // Delete a team (body based)
     const body = await request.json().catch(() => ({}))
+
+    // Delete a single tier — only allowed if it has no placements and no
+    // matches reference it (via tierNumber + season). Use this to drop a
+    // tier that exists in the DB but isn't actually being used.
+    if (body.action === 'delete-tier') {
+      const { tierId } = body
+      if (!tierId) return NextResponse.json({ error: 'tierId required' }, { status: 400 })
+      const tier = await prisma.tier.findUnique({ where: { id: tierId } })
+      if (!tier) return NextResponse.json({ error: 'Tier not found' }, { status: 404 })
+      const placementCount = await prisma.tierPlacement.count({ where: { tierId } })
+      if (placementCount > 0) {
+        return NextResponse.json({ error: `Tier has ${placementCount} placement(s); remove them first.` }, { status: 409 })
+      }
+      const matchCount = await prisma.match.count({
+        where: { tierNumber: tier.tierNumber, week: { seasonId: tier.seasonId } },
+      })
+      if (matchCount > 0) {
+        return NextResponse.json({ error: `Tier has ${matchCount} match(es); cannot delete.` }, { status: 409 })
+      }
+      await prisma.tier.delete({ where: { id: tierId } })
+      return NextResponse.json({ success: true })
+    }
     if (body.teamId) {
       const teamId = body.teamId
       // Delete in order: playerStats → setScores (via matches) → matches → tierPlacements → players → team

--- a/components/tournament/MatchCard.js
+++ b/components/tournament/MatchCard.js
@@ -125,6 +125,7 @@ export default function MatchCard({ match, variant = 'pool', poolTeams = null, s
           opposingPerSet={sortedScores.map(s => s.awayScore)}
           showNumbers={match.status !== 'scheduled'}
           mode={mode}
+          variant={variant}
         />
         <TeamRow
           name={away}
@@ -134,8 +135,31 @@ export default function MatchCard({ match, variant = 'pool', poolTeams = null, s
           opposingPerSet={sortedScores.map(s => s.homeScore)}
           showNumbers={match.status !== 'scheduled'}
           mode={mode}
+          variant={variant}
         />
       </div>
+      {/* Bracket-only per-set strip. The narrow bracket card can't fit
+          inline per-set columns + a sets-won pill + a readable team name,
+          so we drop the inline columns from the team rows and surface the
+          set-by-set scores here as a single compact line under both teams.
+          Each set is a tiny home–away pair, with the set winner's score
+          weighted bold so the rhythm of "who took which set" still reads
+          at a glance. */}
+      {variant === 'bracket' && sortedScores.length > 0 && match.status !== 'scheduled' && (
+        <div className="px-3 py-1.5 border-t border-titos-border/30 flex items-center justify-center gap-2 text-[11px] tabular-nums">
+          {sortedScores.map((s, i) => {
+            const w = setWinnerAt(s, i, mode)
+            return (
+              <span key={s.setNumber ?? i} className="inline-flex items-center gap-0.5">
+                <span className="text-[9px] font-bold uppercase tracking-wider text-titos-gray-600 mr-0.5">S{s.setNumber ?? i + 1}</span>
+                <span className={cn(w === 'home' ? 'font-bold text-titos-white' : 'text-titos-gray-500')}>{s.homeScore}</span>
+                <span className="text-titos-gray-700">–</span>
+                <span className={cn(w === 'away' ? 'font-bold text-titos-white' : 'text-titos-gray-500')}>{s.awayScore}</span>
+              </span>
+            )
+          })}
+        </div>
+      )}
       {refName && (
         <div className="px-3 py-1.5 border-t border-titos-border/30 bg-titos-elevated/40 text-[11px] text-titos-gray-400 flex items-center gap-1.5">
           <UserCheck className="w-3 h-3 text-titos-gray-500 shrink-0" aria-hidden="true" />
@@ -147,7 +171,12 @@ export default function MatchCard({ match, variant = 'pool', poolTeams = null, s
   )
 }
 
-function TeamRow({ name, winner, setsWon, perSet, opposingPerSet, showNumbers, mode }) {
+function TeamRow({ name, winner, setsWon, perSet, opposingPerSet, showNumbers, mode, variant }) {
+  // Bracket cards are only ~14.5rem wide — inline per-set columns crush
+  // the team name. Bracket variant shows just the sets-won pill (the
+  // number that actually matters in a tree) and surfaces per-set detail
+  // in a strip below both team rows.
+  const isBracket = variant === 'bracket'
   return (
     <div
       className={cn(
@@ -165,10 +194,7 @@ function TeamRow({ name, winner, setsWon, perSet, opposingPerSet, showNumbers, m
       </span>
       {showNumbers && (
         <div className="flex items-center gap-1 shrink-0">
-          {perSet.map((pts, i) => {
-            // Only emphasise the winner's score once the set is actually
-            // complete — a mid-set lead stays neutral. Reconstructing as
-            // {homeScore=me, awayScore=them}, a 'home' winner means this side.
+          {!isBracket && perSet.map((pts, i) => {
             const wonSet =
               setWinnerAt(
                 { homeScore: pts, awayScore: opposingPerSet[i] ?? 0 },
@@ -180,10 +206,6 @@ function TeamRow({ name, winner, setsWon, perSet, opposingPerSet, showNumbers, m
                 key={i}
                 className={cn(
                   'min-w-[1.75rem] sm:min-w-[2.5rem] text-center text-sm tabular-nums',
-                  // Step up the emphasis for winning scores: bold + full
-                  // white; losing scores drop to semibold gray so the set
-                  // winner pops at a glance without needing the S1/S2/S3
-                  // column headers to parse the readout.
                   wonSet
                     ? 'font-bold text-titos-white'
                     : 'font-medium text-titos-gray-500',
@@ -193,13 +215,10 @@ function TeamRow({ name, winner, setsWon, perSet, opposingPerSet, showNumbers, m
               </span>
             )
           })}
-          {/* Sets-won total — pill-ified with its own bg so the divider
-              isn't the only affordance separating "score of set 3" from
-              "total sets won". Makes the column read as a clear summary,
-              not another set score. */}
           <span
             className={cn(
-              'ml-1 sm:ml-1.5 inline-flex items-center justify-center min-w-[1.75rem] sm:min-w-[2rem] h-7 px-1.5 rounded-md text-sm font-black tabular-nums',
+              'inline-flex items-center justify-center h-7 px-2 rounded-md text-base font-black tabular-nums',
+              isBracket ? 'min-w-[2rem]' : 'ml-1 sm:ml-1.5 min-w-[1.75rem] sm:min-w-[2rem] text-sm px-1.5',
               winner
                 ? 'bg-titos-gold/25 text-titos-gold ring-1 ring-titos-gold/40'
                 : 'bg-titos-elevated/60 text-titos-gray-300',

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -109,9 +109,6 @@ const sundayMENSTeams = [
   { name: 'Vertical Limit', captain: 'Sean Murphy', email: 'sean.murphy@email.com' },
   { name: 'Slam Dunk VB', captain: 'Tony Russo', email: 'tony.russo@email.com' },
   { name: 'Full Send', captain: 'Liam Fletcher', email: 'liam.fletcher@email.com' },
-  { name: 'Zero Gravity', captain: 'Ravi Sharma', email: 'ravi.sharma@email.com' },
-  { name: 'Side Out Kings', captain: 'James O\'Brien', email: 'james.obrien@email.com' },
-  { name: 'Service Aces', captain: 'Miles Henderson', email: 'miles.henderson@email.com' },
 ]
 
 // Tuesday COED: 8 tiers, early slot 8PM-10PM, late slot 10PM-12AM
@@ -126,13 +123,12 @@ const tuesdayTierDefs = [
   { tierNumber: 8, courtNumber: 10, timeSlot: 'late' },
 ]
 
-// Sunday MENS: 5 tiers, 5 courts, single time slot 9PM-12AM
+// Sunday MENS: 4 tiers, 4 courts, single time slot 9PM-12AM
 const sundayTierDefs = [
-  { tierNumber: 1, courtNumber: 7, timeSlot: 'single' },
-  { tierNumber: 2, courtNumber: 6, timeSlot: 'single' },
-  { tierNumber: 3, courtNumber: 8, timeSlot: 'single' },
-  { tierNumber: 4, courtNumber: 9, timeSlot: 'single' },
-  { tierNumber: 5, courtNumber: 10, timeSlot: 'single' },
+  { tierNumber: 1, courtNumber: 6, timeSlot: 'single' },
+  { tierNumber: 2, courtNumber: 8, timeSlot: 'single' },
+  { tierNumber: 3, courtNumber: 9, timeSlot: 'single' },
+  { tierNumber: 4, courtNumber: 10, timeSlot: 'single' },
 ]
 
 // ─── MATCH & TIER SIMULATION ENGINE ───
@@ -440,7 +436,7 @@ async function main() {
   console.log('Simulating Tuesday COED season...')
 
   const totalTueTiers = 8
-  const totalSunTiers = 5
+  const totalSunTiers = 4
 
   // Week 1: Random placement (completed)
   console.log('  Week 1 (Placement — completed)...')

--- a/scripts/update-mens-courts.mjs
+++ b/scripts/update-mens-courts.mjs
@@ -1,0 +1,94 @@
+// One-off: remap Sunday MENS tier→court for the active season.
+//
+//   Tier 1: Court 7 → 6
+//   Tier 2: Court 6 → 8
+//   Tier 3: Court 8 → 9
+//   Tier 4: Court 9 → 10
+//
+// Updates Tier.courtNumber AND Match.courtNumber for upcoming weeks
+// (weeks whose date is >= today). Completed weeks keep their historical
+// court numbers untouched.
+//
+// Run:  node scripts/update-mens-courts.mjs                 (dry-run)
+//       node scripts/update-mens-courts.mjs --apply         (writes)
+
+import 'dotenv/config'
+
+const APPLY = process.argv.includes('--apply')
+
+// Tier → court mapping (the SAME tierNumbers, new court numbers).
+const NEW_COURTS = { 1: 6, 2: 8, 3: 9, 4: 10 }
+
+const { default: prisma } = await import('../lib/prisma.js')
+
+const league = await prisma.league.findFirst({
+  where: { slug: { contains: 'sunday' } },
+})
+if (!league) {
+  console.error('No Sunday MENS league found.')
+  process.exit(1)
+}
+console.log(`League: ${league.name} (slug=${league.slug})`)
+
+const season = await prisma.season.findFirst({
+  where: { leagueId: league.id, status: { in: ['active', 'registration'] } },
+  orderBy: { seasonNumber: 'desc' },
+})
+if (!season) {
+  console.error('No active/registration season for this league.')
+  process.exit(1)
+}
+console.log(`Season: ${season.name} (#${season.seasonNumber}, status=${season.status})`)
+
+const tiers = await prisma.tier.findMany({
+  where: { seasonId: season.id },
+  orderBy: { tierNumber: 'asc' },
+})
+console.log(`\nCurrent tiers (${tiers.length}):`)
+for (const t of tiers) {
+  const next = NEW_COURTS[t.tierNumber]
+  const change = next != null && next !== t.courtNumber ? `→ Court ${next}` : '(no change)'
+  console.log(`  Tier ${t.tierNumber}: Court ${t.courtNumber} ${change}`)
+}
+
+const today = new Date()
+today.setHours(0, 0, 0, 0)
+const upcomingWeeks = await prisma.week.findMany({
+  where: { seasonId: season.id, date: { gte: today } },
+  orderBy: { weekNumber: 'asc' },
+})
+console.log(`\nUpcoming weeks (${upcomingWeeks.length}):`)
+for (const w of upcomingWeeks) {
+  console.log(`  W${w.weekNumber} ${w.date.toISOString().slice(0, 10)}`)
+}
+
+if (!APPLY) {
+  console.log('\nDRY RUN — pass --apply to write changes.')
+  process.exit(0)
+}
+
+console.log('\nApplying...')
+let tierUpdates = 0
+let matchUpdates = 0
+
+for (const t of tiers) {
+  const next = NEW_COURTS[t.tierNumber]
+  if (next == null || next === t.courtNumber) continue
+  await prisma.tier.update({
+    where: { id: t.id },
+    data: { courtNumber: next },
+  })
+  tierUpdates++
+
+  const res = await prisma.match.updateMany({
+    where: {
+      weekId: { in: upcomingWeeks.map((w) => w.id) },
+      tierNumber: t.tierNumber,
+    },
+    data: { courtNumber: next },
+  })
+  matchUpdates += res.count
+}
+
+console.log(`\nDone. ${tierUpdates} tier(s) updated, ${matchUpdates} upcoming match court(s) updated.`)
+await prisma.$disconnect()


### PR DESCRIPTION
- Bracket MatchCard: drop inline per-set columns from team rows (they crushed team names in the 14.5rem-wide card) and surface set-by-set scores in a compact strip below both teams. Sets-won pill is now the primary score on bracket cards.
- New /admin/courts page: pick a season, edit each tier's court number, save (also rewrites Match.courtNumber on upcoming weeks). Includes a delete-tier action for empty tiers (e.g. legacy Tier 5).
- Seasons API: add `update-tier-court` PATCH and `delete-tier` DELETE actions, both with safety checks (delete blocked when placements or matches still reference the tier).
- Seed: Sunday MENS realigned to 4 tiers on courts 6/8/9/10 (was 5 tiers on 7/6/8/9/10). Trimmed seed teams 15→12 to match.
- scripts/update-mens-courts.mjs: one-off remap script (dry-run by default) for prod DBs that pre-date the admin UI.