### PR TITLE
feat: Thursday REC COED time labels, photos links, tier slot editing

### DIFF
--- a/app/admin/courts/page.js
+++ b/app/admin/courts/page.js
@@ -50,28 +50,42 @@ function AuthGate({ onAuth }) {
 
 function TierRow({ tier, onSaved }) {
   const [court, setCourt] = useState(String(tier.courtNumber))
+  const [slot, setSlot] = useState(tier.timeSlot || 'early')
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [msg, setMsg] = useState('')
   const [err, setErr] = useState('')
 
-  const dirty = String(tier.courtNumber) !== court.trim() && court.trim() !== ''
+  const courtDirty = String(tier.courtNumber) !== court.trim() && court.trim() !== ''
+  const slotDirty = tier.timeSlot !== slot
+  const dirty = courtDirty || slotDirty
 
   const save = async () => {
     const ct = parseInt(court, 10)
     if (!Number.isFinite(ct)) { setErr('Enter a number'); return }
     setSaving(true); setErr(''); setMsg('')
     try {
-      const res = await fetch('/api/admin/seasons', {
-        method: 'PATCH', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'update-tier-court', tierId: tier.id, courtNumber: ct }),
-      })
-      const data = await res.json()
-      if (!res.ok) setErr(data.error || 'Failed')
-      else {
-        setMsg(`Saved (${data.matchesUpdated} upcoming match${data.matchesUpdated === 1 ? '' : 'es'} updated)`)
-        onSaved?.()
+      const messages = []
+      if (courtDirty) {
+        const res = await fetch('/api/admin/seasons', {
+          method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'update-tier-court', tierId: tier.id, courtNumber: ct }),
+        })
+        const data = await res.json()
+        if (!res.ok) { setErr(data.error || 'Failed'); setSaving(false); return }
+        messages.push(`court → ${ct} (${data.matchesUpdated} match${data.matchesUpdated === 1 ? '' : 'es'} updated)`)
       }
+      if (slotDirty) {
+        const res = await fetch('/api/admin/seasons', {
+          method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action: 'update-tier-slot', tierId: tier.id, timeSlot: slot }),
+        })
+        const data = await res.json()
+        if (!res.ok) { setErr(data.error || 'Failed'); setSaving(false); return }
+        messages.push(`slot → ${slot}`)
+      }
+      setMsg(`Saved: ${messages.join(', ')}`)
+      onSaved?.()
     } catch { setErr('Network error') }
     setSaving(false)
   }
@@ -93,9 +107,8 @@ function TierRow({ tier, onSaved }) {
 
   return (
     <div className="card-flat rounded-xl px-4 py-3 flex flex-wrap items-center gap-3">
-      <div className="min-w-[6rem]">
+      <div className="min-w-[5rem]">
         <span className="font-display text-base font-black text-titos-white">Tier {tier.tierNumber}</span>
-        <span className="block text-[11px] text-titos-gray-500 uppercase tracking-wider">{tier.timeSlot}</span>
       </div>
       <label className="flex items-center gap-2 text-sm text-titos-gray-300">
         Court
@@ -107,6 +120,18 @@ function TierRow({ tier, onSaved }) {
           onChange={(e) => setCourt(e.target.value)}
           className="w-20 px-2 py-1.5 bg-titos-surface border border-titos-border rounded text-center text-titos-white font-bold focus:outline-none focus:border-titos-gold focus:ring-1 focus:ring-titos-gold/30"
         />
+      </label>
+      <label className="flex items-center gap-2 text-sm text-titos-gray-300">
+        Slot
+        <select
+          value={slot}
+          onChange={(e) => setSlot(e.target.value)}
+          className="px-2 py-1.5 bg-titos-surface border border-titos-border rounded text-titos-white font-semibold focus:outline-none focus:border-titos-gold focus:ring-1 focus:ring-titos-gold/30"
+        >
+          <option value="early">early</option>
+          <option value="late">late</option>
+          <option value="single">single</option>
+        </select>
       </label>
       <button
         onClick={save}

--- a/app/admin/page.js
+++ b/app/admin/page.js
@@ -45,8 +45,8 @@ function AuthGate({ onAuth }) {
 }
 
 // ─── Score Entry Table (per tier) ───
-function TierScoreBlock({ tierNum, tierMatches, inputRefs, onScoreChange, allInputKeys }) {
-  const slot = getSlotInfo(parseInt(tierNum), tierMatches[0]?.timeSlot)
+function TierScoreBlock({ tierNum, tierMatches, inputRefs, onScoreChange, allInputKeys, leagueSlug }) {
+  const slot = getSlotInfo(parseInt(tierNum), tierMatches[0]?.timeSlot, leagueSlug)
   const slotVar = parseInt(tierNum) <= 4 ? 'slot-early' : parseInt(tierNum) <= 8 ? 'slot-late' : 'slot-single'
 
   const handleKeyDown = (e, matchId, field) => {
@@ -121,7 +121,7 @@ function TierScoreBlock({ tierNum, tierMatches, inputRefs, onScoreChange, allInp
 }
 
 // ─── Results Tab ───
-function ResultsView({ matches }) {
+function ResultsView({ matches, leagueSlug }) {
   // Group by tier, compute standings
   const byTier = {}
   for (const m of matches) {
@@ -132,7 +132,7 @@ function ResultsView({ matches }) {
   return (
     <div className="space-y-4">
       {Object.entries(byTier).sort(([a], [b]) => a - b).map(([tierNum, tierMatches]) => {
-        const slot = getSlotInfo(parseInt(tierNum), tierMatches[0]?.timeSlot)
+        const slot = getSlotInfo(parseInt(tierNum), tierMatches[0]?.timeSlot, leagueSlug)
         const slotVar = parseInt(tierNum) <= 4 ? 'slot-early' : parseInt(tierNum) <= 8 ? 'slot-late' : 'slot-single'
         // Build team stats
         const stats = {}
@@ -730,7 +730,7 @@ export default function AdminPage() {
                     <div className="space-y-4">
                       {Object.entries(matchesByTier).sort(([a], [b]) => a - b).map(([tierNum, tierMatches]) => (
                         <TierScoreBlock key={tierNum} tierNum={tierNum} tierMatches={tierMatches} inputRefs={inputRefs}
-                          onScoreChange={updateMatchScore} allInputKeys={allInputKeys} />
+                          onScoreChange={updateMatchScore} allInputKeys={allInputKeys} leagueSlug={activeLeague?.slug} />
                       ))}
                     </div>
                     {matches.length === 0 && <p className="text-titos-gray-400 text-center py-8">No matches for this week.</p>}
@@ -738,7 +738,7 @@ export default function AdminPage() {
                 )}
 
                 {/* RESULTS TAB */}
-                {activeTab === 'Results' && <ResultsView matches={matches} />}
+                {activeTab === 'Results' && <ResultsView matches={matches} leagueSlug={activeLeague?.slug} />}
 
                 {/* TIERS TAB */}
                 {activeTab === 'Tiers' && selectedWeek && <TiersView weekId={selectedWeek.id} weeks={weeks} onReloadMatches={loadMatches} />}

--- a/app/admin/scores/page.js
+++ b/app/admin/scores/page.js
@@ -203,7 +203,7 @@ export default function ScoreEntryPage() {
         ) : (
           <div className="space-y-4">
             {Object.entries(matchesByTier).sort(([a], [b]) => a - b).map(([tierNum, tierMatches]) => {
-              const slot = getSlotInfo(parseInt(tierNum), tierMatches[0]?.timeSlot)
+              const slot = getSlotInfo(parseInt(tierNum), tierMatches[0]?.timeSlot, selectedLeague)
               const slotVar = parseInt(tierNum) <= 4 ? 'slot-early' : parseInt(tierNum) <= 8 ? 'slot-late' : 'slot-single'
 
               return (

--- a/app/api/admin/seasons/route.js
+++ b/app/api/admin/seasons/route.js
@@ -1,6 +1,18 @@
 import prisma from '@/lib/prisma'
 import { NextResponse } from 'next/server'
 import { slugify } from '@/lib/utils'
+import { revalidateLeague } from '@/lib/server/leagues'
+
+// Resolve a tier's league slug so we can bust public schedule/standings
+// caches after a write. Returns null if the tier was deleted in the same
+// request — caller should fall back gracefully.
+async function leagueSlugForTier(tierId) {
+  const tier = await prisma.tier.findUnique({
+    where: { id: tierId },
+    select: { season: { select: { league: { select: { slug: true } } } } },
+  })
+  return tier?.season?.league?.slug || null
+}
 
 export const dynamic = 'force-dynamic'
 
@@ -116,8 +128,20 @@ export async function POST(request) {
         for (const t of mensTiers) {
           await prisma.tier.create({ data: { seasonId: season.id, ...t } })
         }
+      } else if (league.slug.includes('thursday')) {
+        // Thursday REC COED: 4 tiers, 6:30–8:30 PM (early) for 1-2,
+        // 8:30–10:30 PM (late) for 3-4. Courts 9 & 10 only.
+        const thursdayTiers = [
+          { tierNumber: 1, courtNumber: 9, timeSlot: 'early' },
+          { tierNumber: 2, courtNumber: 10, timeSlot: 'early' },
+          { tierNumber: 3, courtNumber: 9, timeSlot: 'late' },
+          { tierNumber: 4, courtNumber: 10, timeSlot: 'late' },
+        ]
+        for (const t of thursdayTiers) {
+          await prisma.tier.create({ data: { seasonId: season.id, ...t } })
+        }
       } else {
-        // COED: 8 tiers, courts 6,8,9,10, early/late slots
+        // Tuesday COED: 8 tiers, courts 6,8,9,10, early/late slots
         const coedTiers = [
           { tierNumber: 1, courtNumber: 6, timeSlot: 'early' },
           { tierNumber: 2, courtNumber: 8, timeSlot: 'early' },
@@ -174,7 +198,26 @@ export async function PATCH(request) {
         },
         data: { courtNumber: ct },
       })
+      const slug = await leagueSlugForTier(tierId)
+      if (slug) revalidateLeague(slug)
       return NextResponse.json({ success: true, matchesUpdated: result.count })
+    }
+
+    // Update a single tier's timeSlot ('early' | 'late' | 'single').
+    // Tier.timeSlot is metadata used to group tiers in the schedule view —
+    // doesn't propagate to Match records (matches don't carry timeSlot).
+    if (body.action === 'update-tier-slot') {
+      const { tierId, timeSlot } = body
+      const allowed = ['early', 'late', 'single']
+      if (!tierId || !allowed.includes(timeSlot)) {
+        return NextResponse.json({ error: 'tierId and valid timeSlot required' }, { status: 400 })
+      }
+      const tier = await prisma.tier.findUnique({ where: { id: tierId } })
+      if (!tier) return NextResponse.json({ error: 'Tier not found' }, { status: 404 })
+      await prisma.tier.update({ where: { id: tierId }, data: { timeSlot } })
+      const slug = await leagueSlugForTier(tierId)
+      if (slug) revalidateLeague(slug)
+      return NextResponse.json({ success: true })
     }
 
     // Update team action

--- a/app/leagues/[slug]/LeagueDetailClient.js
+++ b/app/leagues/[slug]/LeagueDetailClient.js
@@ -4,6 +4,8 @@ import { useState, Fragment } from 'react'
 import Link from 'next/link'
 import { Calendar, Users, Trophy, ArrowUp, ArrowDown, ArrowRight, Minus, MapPin } from 'lucide-react'
 import StatusBadge from '@/components/ui/StatusBadge'
+import PhotosLink from '@/components/PhotosLink'
+import { getLeaguePhotosUrl } from '@/lib/photoLinks'
 import { cn, formatDate, getTierColor, getSlotInfo, getDivisionInfo, getMovementIcon, getTeamAbbreviation, getLeagueTimeDisplay } from '@/lib/utils'
 
 export default function LeagueDetailClient({ data }) {
@@ -32,11 +34,13 @@ export default function LeagueDetailClient({ data }) {
   const leagueType = (league.slug && (league.slug.includes('sunday') || league.slug.includes('mens'))) ? 'mens' : 'coed'
   const timeDisplay = getLeagueTimeDisplay(league.slug)
 
-  // Time slot labels vary by league type
+  // Time slot labels vary by league type. Thursday REC COED runs an
+  // earlier schedule than Tuesday COED, so we don't hardcode 8/10 PM.
   const isMens = leagueType === 'mens'
+  const isThursday = league.slug && league.slug.includes('thursday')
   const singleSlotLabel = '9:00 PM – 12:00 AM'
-  const earlySlotLabel = '8:00 PM – 10:00 PM'
-  const lateSlotLabel = '10:00 PM – 12:00 AM'
+  const earlySlotLabel = isThursday ? '6:30 PM – 8:30 PM' : '8:00 PM – 10:00 PM'
+  const lateSlotLabel = isThursday ? '8:30 PM – 10:30 PM' : '10:00 PM – 12:00 AM'
   const numRounds = isMens ? 3 : 2
 
   return (
@@ -54,12 +58,13 @@ export default function LeagueDetailClient({ data }) {
               <h1 className="font-display text-3xl sm:text-4xl font-bold text-titos-white">{league.name}</h1>
               <p className="text-titos-gold font-semibold mt-1">{season.name}</p>
             </div>
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 flex-wrap">
               <StatusBadge status={season.status} />
               <span className="text-titos-gray-400 text-sm flex items-center gap-1.5">
                 <Calendar className="w-4 h-4" />
                 {league.dayOfWeek}s &middot; {timeDisplay}
               </span>
+              <PhotosLink url={getLeaguePhotosUrl(league.slug)} size="sm" />
             </div>
           </div>
 
@@ -476,7 +481,7 @@ function ResultsTab({ weeks, league, completedWeeks, lastCompletedWeek, currentW
 
           <div className="space-y-4">
             {tiers.map(({ tier, teams, matches }) => {
-              const slot = getSlotInfo(tier.tierNumber, tier.timeSlot)
+              const slot = getSlotInfo(tier.tierNumber, tier.timeSlot, league.slug)
               const slotVar = tier.tierNumber <= 4 ? 'slot-early' : 'slot-late'
               const sortedTeams = [...teams].sort((a, b) => (a.finishPosition || 99) - (b.finishPosition || 99))
 
@@ -701,7 +706,7 @@ function ScheduleTab({ weeks, league }) {
                   {filteredTiers.length > 0 ? (
                     <div className="space-y-4">
                       {filteredTiers.map(({ tier, teams, matches }) => {
-                        const slotC = getSlotInfo(tier.tierNumber, tier.timeSlot)
+                        const slotC = getSlotInfo(tier.tierNumber, tier.timeSlot, league.slug)
                         const slotVar = tier.tierNumber <= 4 ? 'slot-early' : 'slot-late'
                         return (
                           <div key={tier.tierNumber} className="bg-titos-surface rounded-xl overflow-hidden border border-titos-border/30">

--- a/app/results/ResultsClient.js
+++ b/app/results/ResultsClient.js
@@ -248,9 +248,9 @@ function ResultPanel({ tier, slotColorVar, compact = false }) {
 /* ═══════════════════════════════════════════════
    SLOT GROUP — manages which tier is expanded
    ═══════════════════════════════════════════════ */
-function SlotGroup({ slot, tiers }) {
+function SlotGroup({ slot, tiers, leagueSlug }) {
   const [expandedTier, setExpandedTier] = useState(null)
-  const slotInfo = getSlotInfo(tiers[0].tierNumber, slot)
+  const slotInfo = getSlotInfo(tiers[0].tierNumber, slot, leagueSlug)
   const slotColorVar = slot === 'early' ? 'slot-early' : slot === 'late' ? 'slot-late' : 'slot-single'
   const sorted = [...tiers].sort((a, b) => a.tierNumber - b.tierNumber)
 
@@ -473,7 +473,7 @@ export default function ResultsClient({ leagues, initialSlug, initialData }) {
                 {['early', 'late', 'single'].map(slot => {
                   const slotTiers = tiersBySlot[slot]
                   if (!slotTiers?.length) return null
-                  return <SlotGroup key={slot} slot={slot} tiers={slotTiers} />
+                  return <SlotGroup key={slot} slot={slot} tiers={slotTiers} leagueSlug={selected} />
                 })}
               </div>
             ) : (

--- a/app/schedule/ScheduleClient.js
+++ b/app/schedule/ScheduleClient.js
@@ -243,9 +243,9 @@ function MatchPanel({ tier, myTeam, slotColorVar, isMens, compact = false }) {
 /* ═══════════════════════════════════════════════
    SLOT GROUP — manages which tier is expanded
    ═══════════════════════════════════════════════ */
-function SlotGroup({ slot, tiers, myTeam, isMens }) {
+function SlotGroup({ slot, tiers, myTeam, isMens, leagueSlug }) {
   const [expandedTier, setExpandedTier] = useState(null)
-  const slotInfo = getSlotInfo(tiers[0].tierNumber, slot)
+  const slotInfo = getSlotInfo(tiers[0].tierNumber, slot, leagueSlug)
   const slotColorVar = slot === 'early' ? 'slot-early' : slot === 'late' ? 'slot-late' : 'slot-single'
   const sorted = [...tiers].sort((a, b) => a.tierNumber - b.tierNumber)
 
@@ -344,7 +344,7 @@ export default function ScheduleClient({ leagues, initialSlug, initialData }) {
     for (const tier of (currentGameWeek.tiers || [])) {
       const found = tier.teams?.find(t => t.name === myTeam)
       if (found) {
-        const slot = getSlotInfo(tier.tierNumber, tier.timeSlot)
+        const slot = getSlotInfo(tier.tierNumber, tier.timeSlot, selected)
         const opponents = tier.teams.filter(t => t.name !== myTeam).map(t => t.name)
         return { tier: tier.tierNumber, court: tier.courtNumber, slotLabel: slot.label, opponents, slot }
       }
@@ -486,7 +486,7 @@ export default function ScheduleClient({ leagues, initialSlug, initialData }) {
                     {['early', 'late', 'single'].map(slot => {
                       const slotTiers = currentGameWeek.tiers.filter(t => t.timeSlot === slot)
                       if (!slotTiers.length) return null
-                      return <SlotGroup key={slot} slot={slot} tiers={slotTiers} myTeam={myTeam} isMens={isMens} />
+                      return <SlotGroup key={slot} slot={slot} tiers={slotTiers} myTeam={myTeam} isMens={isMens} leagueSlug={selected} />
                     })}
                   </div>
                 ) : (

--- a/app/tournaments/[slug]/page.js
+++ b/app/tournaments/[slug]/page.js
@@ -7,6 +7,8 @@ import { formatDate } from '@/lib/utils'
 import { getTournamentHub } from '@/lib/server/tournaments'
 import TournamentHubClient from './TournamentHubClient'
 import Countdown from '@/components/tournament/Countdown'
+import PhotosLink from '@/components/PhotosLink'
+import { getTournamentPhotosUrl } from '@/lib/photoLinks'
 import { TOURNAMENT_STATUS } from '@/lib/tournament/constants'
 
 export const dynamic = 'force-dynamic'
@@ -104,6 +106,7 @@ export default async function TournamentDetailPage({ params }) {
             >
               <Trophy className="h-4 w-4" aria-hidden="true" /> View Bracket
             </Link>
+            <PhotosLink url={getTournamentPhotosUrl(slug)} />
           </div>
         </section>
       )}
@@ -113,13 +116,14 @@ export default async function TournamentDetailPage({ params }) {
 
         {/* Secondary bracket CTA for completed/live tournaments (upcoming already has the sticky CTA above) */}
         {!(isUpcoming && hasFutureDate) && (
-          <div className="mt-12 text-center">
+          <div className="mt-12 flex flex-wrap items-center justify-center gap-3">
             <Link
               href={`/tournaments/${slug}/bracket`}
               className="inline-flex items-center gap-2 rounded-full bg-titos-gold px-6 py-3 text-sm font-semibold text-titos-surface hover:bg-titos-gold-light transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-titos-gold focus-visible:ring-offset-2 focus-visible:ring-offset-titos-surface"
             >
               <Trophy className="w-4 h-4" aria-hidden="true" /> View Bracket
             </Link>
+            <PhotosLink url={getTournamentPhotosUrl(slug)} />
           </div>
         )}
       </div>

--- a/components/PhotosLink.js
+++ b/components/PhotosLink.js
@@ -1,0 +1,30 @@
+import { Camera, ExternalLink } from 'lucide-react'
+
+// "Photos" CTA — opens a Google Drive folder in a new tab. Renders
+// nothing when no URL is provided so callers can drop it in
+// unconditionally.
+//
+// Visual weight is intentionally secondary (outline, not filled gold)
+// so it doesn't compete with primary CTAs like "View Bracket" on the
+// same page.
+
+export default function PhotosLink({ url, label = 'Photos', size = 'md', className = '' }) {
+  if (!url) return null
+  const sizeClasses = size === 'sm'
+    ? 'px-3 py-1.5 text-xs gap-1.5'
+    : 'px-4 py-2 text-sm gap-2'
+  const iconSize = size === 'sm' ? 'w-3.5 h-3.5' : 'w-4 h-4'
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`inline-flex items-center justify-center rounded-full border border-titos-gold/40 bg-titos-gold/10 text-titos-gold font-semibold cursor-pointer hover:bg-titos-gold/20 hover:border-titos-gold/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-titos-gold focus-visible:ring-offset-2 focus-visible:ring-offset-titos-surface ${sizeClasses} ${className}`}
+      aria-label={`${label} (opens Google Drive in a new tab)`}
+    >
+      <Camera className={iconSize} aria-hidden="true" />
+      {label}
+      <ExternalLink className={`${iconSize} opacity-60`} aria-hidden="true" />
+    </a>
+  )
+}

--- a/lib/photoLinks.js
+++ b/lib/photoLinks.js
@@ -1,0 +1,25 @@
+// Slug → Google Drive folder URL for photos. Edit this map when a new
+// league season or tournament gets a Drive folder. Keys match the
+// `slug` field on League/Tournament records.
+//
+// Why a static map (and not a DB column): photos are an external
+// dependency (Drive), the URL almost never changes within a season,
+// and we want zero migration overhead to add the link.
+
+const LEAGUE_PHOTOS = {
+  // 'tuesday-coed': 'https://drive.google.com/drive/folders/...',
+  // 'sunday-mens': 'https://drive.google.com/drive/folders/...',
+  // 'thursday-rec-coed': 'https://drive.google.com/drive/folders/...',
+}
+
+const TOURNAMENT_PHOTOS = {
+  // 'spring-showdown': 'https://drive.google.com/drive/folders/...',
+}
+
+export function getLeaguePhotosUrl(slug) {
+  return LEAGUE_PHOTOS[slug] || null
+}
+
+export function getTournamentPhotosUrl(slug) {
+  return TOURNAMENT_PHOTOS[slug] || null
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,12 +44,30 @@ export function getTierColor(tierNumber) {
 }
 
 /**
- * Returns the time slot color and label for a tier.
+ * Returns the time slot color and label for a tier. Pass `leagueSlug`
+ * to get league-specific time labels — Thursday REC COED runs an
+ * earlier schedule (6:30–10:30 PM) than Tuesday COED (8 PM–12 AM).
  */
-export function getSlotInfo(tierNumber, timeSlot) {
+export function getSlotInfo(tierNumber, timeSlot, leagueSlug) {
+  const isThursday = !!(leagueSlug && leagueSlug.includes('thursday'))
   if (timeSlot === 'single') return { color: 'text-slot-single', bg: 'bg-slot-single/10', border: 'border-slot-single/25', label: '9 PM – 12 AM' }
-  if (tierNumber <= 4 || timeSlot === 'early') return { color: 'text-slot-early', bg: 'bg-slot-early/10', border: 'border-slot-early/25', label: '8 – 10 PM' }
-  return { color: 'text-slot-late', bg: 'bg-slot-late/10', border: 'border-slot-late/25', label: '10 PM – 12 AM' }
+  // Thursday has only 4 tiers (1-2 early, 3-4 late) so we defer entirely to timeSlot.
+  // Tuesday COED has 8 tiers and the tierNumber heuristic (≤4 = early) is used as a fallback.
+  const isEarly = isThursday ? timeSlot === 'early' : (tierNumber <= 4 || timeSlot === 'early')
+  if (isEarly) {
+    return {
+      color: 'text-slot-early',
+      bg: 'bg-slot-early/10',
+      border: 'border-slot-early/25',
+      label: isThursday ? '6:30 – 8:30 PM' : '8 – 10 PM',
+    }
+  }
+  return {
+    color: 'text-slot-late',
+    bg: 'bg-slot-late/10',
+    border: 'border-slot-late/25',
+    label: isThursday ? '8:30 – 10:30 PM' : '10 PM – 12 AM',
+  }
 }
 
 /**
@@ -114,11 +132,16 @@ export function getTeamAbbreviation(name) {
 
 /**
  * Returns the time range display string for a league based on slug or day.
- * Sunday/MENS leagues run 9 PM - 12 AM, others run 8 PM - 12 AM.
+ *   Sunday MENS:    9 PM – 12 AM (single slot)
+ *   Thursday REC:   6:30 – 10:30 PM (earlier schedule)
+ *   Tuesday COED:   8 PM – 12 AM (default)
  */
 export function getLeagueTimeDisplay(slug) {
   if (slug && (slug.includes('sunday') || slug.includes('mens'))) {
     return '9 PM – 12 AM'
+  }
+  if (slug && slug.includes('thursday')) {
+    return '6:30 – 10:30 PM'
   }
   return '8 PM – 12 AM'
 }

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -66,6 +66,14 @@ describe('getSlotInfo()', () => {
     const info = getSlotInfo(6, 'late')
     expect(info.label).toBe('10 PM – 12 AM')
   })
+  it('uses Thursday-specific labels for thursday slugs', () => {
+    expect(getSlotInfo(1, 'early', 'thursday-rec-coed').label).toBe('6:30 – 8:30 PM')
+    expect(getSlotInfo(6, 'late', 'thursday-rec-coed').label).toBe('8:30 – 10:30 PM')
+  })
+  it('Thursday tiers 3-4 belong to LATE slot when their timeSlot says so', () => {
+    expect(getSlotInfo(3, 'late', 'thursday-rec-coed').label).toBe('8:30 – 10:30 PM')
+    expect(getSlotInfo(4, 'late', 'thursday-rec-coed').label).toBe('8:30 – 10:30 PM')
+  })
 })
 
 describe('getDivisionInfo()', () => {
@@ -127,8 +135,10 @@ describe('getLeagueTimeDisplay()', () => {
   it('returns 9 PM for Sunday/MENS leagues', () => {
     expect(getLeagueTimeDisplay('sunday-mens')).toBe('9 PM – 12 AM')
   })
-  it('returns 8 PM for other leagues', () => {
+  it('returns 8 PM default for Tuesday COED', () => {
     expect(getLeagueTimeDisplay('tuesday-coed')).toBe('8 PM – 12 AM')
-    expect(getLeagueTimeDisplay('thursday-rec-coed')).toBe('8 PM – 12 AM')
+  })
+  it('returns 6:30 PM for Thursday REC COED (earlier schedule)', () => {
+    expect(getLeagueTimeDisplay('thursday-rec-coed')).toBe('6:30 – 10:30 PM')
   })
 })


### PR DESCRIPTION
- getSlotInfo now accepts leagueSlug; Thursday renders 6:30-8:30 PM (early) and 8:30-10:30 PM (late) instead of Tuesday's 8 PM / 10 PM defaults. Slug threaded through schedule, results, and admin views.
- Thursday-specific seeding branch in seasons-create route: 4 tiers (1-2 early, 3-4 late) instead of the default 8-tier COED layout.
- New update-tier-slot admin action + slot dropdown on /admin/courts so existing Thursday seasons can be migrated without a script.
- update-tier-court / update-tier-slot now revalidate league cache tags so public schedule reflects edits within seconds, not 5 minutes.
- Photos CTA: static slug -> Drive folder map (lib/photoLinks.js) + reusable PhotosLink component, wired into tournament hub and league detail pages. Zero migration overhead.