### PR TITLE
feat(coed): retire Bronze, move to 4-division 6/6/6/6 split

### DIFF
--- a/app/leagues/page.js
+++ b/app/leagues/page.js
@@ -138,7 +138,7 @@ export default async function LeaguesPage() {
                 <h3 className="font-display font-bold text-titos-white">Playoff Divisions</h3>
               </div>
               <p className="text-titos-gray-300 text-sm leading-relaxed">
-                Your cumulative season points determine your playoff division. Five divisions — <strong className="text-titos-gold">Diamond, Platinum, Gold, Silver, and Bronze</strong> — each play a single-elimination bracket on playoff night. Every team competes.
+                Your cumulative season points determine your playoff division. Four divisions — <strong className="text-titos-gold">Diamond, Platinum, Gold, and Silver</strong> — each play a single-elimination bracket on playoff night. Every team competes.
               </p>
             </div>
           </div>

--- a/app/rules/layout.js
+++ b/app/rules/layout.js
@@ -45,7 +45,7 @@ const faqJsonLd = {
       name: 'What happens in the playoffs?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: "End-of-season standings determine your playoff division: Diamond, Platinum, Gold, Silver, or Bronze. Each division plays its own single-elimination bracket.",
+        text: "End-of-season standings determine your playoff division: Diamond, Platinum, Gold, or Silver. Each division plays its own single-elimination bracket — top-2 byes, 3v6 + 4v5 quarterfinals, then SF + Final.",
       },
     },
     {

--- a/app/rules/page.js
+++ b/app/rules/page.js
@@ -59,10 +59,10 @@ const sections = [
     icon: Trophy, title: 'Playoff Format',
     items: [
       'Final overall standings determine playoff division placement',
-      '5 divisions: Diamond, Platinum, Gold, Silver, Bronze — cutoffs scale with total teams per league',
+      '4 divisions: Diamond, Platinum, Gold, Silver — 6 teams per division on a 24-team COED season',
       'Division cutoffs scale with the total number of teams that season',
-      'Single-elimination brackets within each division',
-      'Week 11 is playoff week — every team competes for their division championship',
+      'Single-elimination brackets within each division: top-2 byes, 3v6 + 4v5 in the QFs, SF + Final reseeded',
+      'Weeks 10 + 11 are playoff weeks (W10 = QFs, W11 = SF + Final, championship at 11 PM)',
     ],
   },
   {

--- a/app/standings/[slug]/page.js
+++ b/app/standings/[slug]/page.js
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }) {
   const { slug } = await params
   const label = LEAGUE_LABEL[slug] || slug
   const title = `${label} Volleyball Standings — Mississauga | Tito's Courts`
-  const description = `Live standings for ${label} volleyball league at Tito's Courts in Mississauga. Track team rankings, wins, losses, point differentials, and playoff divisions across Diamond, Platinum, Gold, Silver, and Bronze tiers.`
+  const description = `Live standings for ${label} volleyball league at Tito's Courts in Mississauga. Track team rankings, wins, losses, point differentials, and playoff divisions across Diamond, Platinum, Gold, and Silver tiers.`
   return {
     title,
     description,
@@ -57,7 +57,7 @@ export default async function StandingsLeaguePage({ params }) {
     <>
       {/* Googlebot-indexable copy — hidden visually but semantically first so crawlers see real text */}
       <p className="sr-only">
-        {`Current standings for the ${label} recreational volleyball league at Tito's Courts in Mississauga. Tracks team performance across Diamond, Platinum, Gold, Silver, and Bronze divisions at Pakmen Courts and Michael Power High School.`}
+        {`Current standings for the ${label} recreational volleyball league at Tito's Courts in Mississauga. Tracks team performance across Diamond, Platinum, Gold, and Silver divisions at Pakmen Courts and Michael Power High School.`}
       </p>
       <StandingsClient leagues={leagues} initialSlug={slug} initialData={initialData} />
     </>

--- a/app/standings/page.js
+++ b/app/standings/page.js
@@ -30,7 +30,7 @@ export default async function StandingsPage() {
   return (
     <>
       <p className="sr-only">
-        Current standings for Tito&apos;s Courts recreational volleyball leagues in Mississauga. Tracks team performance across Diamond, Platinum, Gold, Silver, and Bronze divisions for Tuesday Coed, Sunday Men&apos;s, and Thursday Rec Coed leagues at Pakmen Courts.
+        Current standings for Tito&apos;s Courts recreational volleyball leagues in Mississauga. Tracks team performance across Diamond, Platinum, Gold, and Silver divisions for Tuesday Coed, Sunday Men&apos;s, and Thursday Rec Coed leagues at Pakmen Courts.
       </p>
       <StandingsClient leagues={leagues} initialSlug={firstSlug} initialData={initialData} />
     </>

--- a/components/home/HomePageClient.js
+++ b/components/home/HomePageClient.js
@@ -83,7 +83,7 @@ const steps = [
   { num: '01', title: 'REGISTER', desc: 'Sign up with 6+ players. Pick your league night. Pay via e-transfer.', icon: Users },
   { num: '02', title: 'GET PLACED', desc: 'Week 1 placement matches seed your team into a tier of 3 based on skill.', icon: Target },
   { num: '03', title: 'COMPETE', desc: 'Play weekly. Win = move up a tier. Lose = drop down. Every game counts.', icon: Zap },
-  { num: '04', title: 'PLAYOFFS', desc: '5 divisions from Diamond to Bronze. Season-end championship brackets.', icon: Trophy },
+  { num: '04', title: 'PLAYOFFS', desc: '4 divisions from Diamond to Silver. Season-end championship brackets.', icon: Trophy },
 ]
 
 const stats = [

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -78,7 +78,19 @@ export function getSlotInfo(tierNumber, timeSlot, leagueSlug) {
  * don't surface Gold/Silver/Bronze on MENS because there are only two payout
  * tiers; forcing a 5-way split would invent divisions that don't exist.
  *
- * COED (24 teams): Diamond 1-5, Platinum 6-10, Gold 11-15, Silver 16-20, Bronze 21-24.
+ * COED (24 teams): 4-way EVEN split, 6 teams each:
+ *   Diamond  1-6
+ *   Platinum 7-12
+ *   Gold     13-18
+ *   Silver   19-24
+ * Bronze was retired alongside the move to a 4-division payout pool — every
+ * division now lines up with a 6-team single-elim playoff bracket
+ * (top-2 byes + 3v6/4v5 → SF + Final).
+ *
+ * The split scales: we partition `totalTeams` into 4 contiguous buckets with
+ * the extras (Math.ceil) given to the higher-prestige divisions first, so a
+ * 22-team season would land as 6/6/5/5 rather than dropping an unlucky team
+ * into a half-empty Silver. 23 → 6/6/6/5; 26 → 7/7/6/6; etc.
  *
  * Pass leagueType='mens' for the two-way MENS split; defaults to 'coed'.
  */
@@ -88,7 +100,6 @@ export function getDivisionInfo(rank, totalTeams, leagueType = 'coed') {
     { name: 'Platinum', color: 'div-platinum', bgClass: 'division-platinum' },
     { name: 'Gold', color: 'div-gold', bgClass: 'division-gold' },
     { name: 'Silver', color: 'div-silver', bgClass: 'division-silver' },
-    { name: 'Bronze', color: 'div-bronze', bgClass: 'division-bronze' },
   ]
 
   // MENS: single cut down the middle. Odd totals give Diamond the extra seat
@@ -98,12 +109,23 @@ export function getDivisionInfo(rank, totalTeams, leagueType = 'coed') {
     return rank <= half ? divisions[0] : divisions[1]
   }
 
-  // COED structure (24 teams): 5-5-5-5-4
-  if (rank <= 5) return divisions[0]  // Diamond: 1-5
-  if (rank <= 10) return divisions[1] // Platinum: 6-10
-  if (rank <= 15) return divisions[2] // Gold: 11-15
-  if (rank <= 20) return divisions[3] // Silver: 16-20
-  return divisions[4]                 // Bronze: 21-24
+  // COED: 4-way even split with leftovers stacked into the top divisions.
+  // For the canonical 24-team season this is exactly 6/6/6/6.
+  const base = Math.floor(totalTeams / 4)
+  const extras = totalTeams % 4
+  const sizes = [
+    base + (extras > 0 ? 1 : 0), // Diamond
+    base + (extras > 1 ? 1 : 0), // Platinum
+    base + (extras > 2 ? 1 : 0), // Gold
+    base,                        // Silver
+  ]
+  let upper = 0
+  for (let i = 0; i < divisions.length; i++) {
+    upper += sizes[i]
+    if (rank <= upper) return divisions[i]
+  }
+  // Defensive fallback for ranks beyond totalTeams — keep them in Silver.
+  return divisions[divisions.length - 1]
 }
 
 /**

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -295,8 +295,11 @@ async function main() {
       seasonNumber: 10,
       startDate: new Date('2026-04-01T12:00:00Z'),
       endDate: new Date('2026-06-10T12:00:00Z'),
+      // Tuesday COED: 9 regular-season weeks + 2 playoff weeks (W10 QFs,
+      // W11 SF + Final). See lib/utils.getDivisionInfo — divisions are
+      // 4-way (Diamond/Platinum/Gold/Silver, 6 teams each).
       totalWeeks: 11,
-      playoffWeeks: 1,
+      playoffWeeks: 2,
       status: 'active',
     },
   })

--- a/scripts/update-coed-season-config.mjs
+++ b/scripts/update-coed-season-config.mjs
@@ -1,0 +1,49 @@
+// Updates the active Tuesday COED season's structure:
+//   - totalWeeks: 11 (9 regular + 2 playoff)
+//   - playoffWeeks: 2 (Week 10 + Week 11)
+//   - Flags weeks 10 & 11 with isPlayoff=true
+// Idempotent — re-running is safe.
+
+import 'dotenv/config'
+import prisma from '../lib/prisma.js'
+
+const SLUG = 'tuesday-coed'
+const REGULAR_SEASON_WEEKS = 9
+const PLAYOFF_WEEKS = 2
+
+const league = await prisma.league.findUnique({
+  where: { slug: SLUG },
+  include: {
+    seasons: {
+      where: { status: { in: ['active', 'playoffs'] } },
+      orderBy: { seasonNumber: 'desc' },
+      take: 1,
+      include: { weeks: { orderBy: { weekNumber: 'asc' } } },
+    },
+  },
+})
+const season = league?.seasons?.[0]
+if (!season) { console.error('No active Tuesday COED season'); process.exit(1) }
+console.log(`Season: ${season.name} (${season.id})`)
+
+await prisma.season.update({
+  where: { id: season.id },
+  data: {
+    totalWeeks: REGULAR_SEASON_WEEKS + PLAYOFF_WEEKS,
+    playoffWeeks: PLAYOFF_WEEKS,
+  },
+})
+console.log(`  totalWeeks → ${REGULAR_SEASON_WEEKS + PLAYOFF_WEEKS}, playoffWeeks → ${PLAYOFF_WEEKS}`)
+
+for (const w of season.weeks) {
+  const shouldBePlayoff = w.weekNumber > REGULAR_SEASON_WEEKS
+  if (w.isPlayoff !== shouldBePlayoff) {
+    await prisma.week.update({
+      where: { id: w.id },
+      data: { isPlayoff: shouldBePlayoff },
+    })
+    console.log(`  Week ${w.weekNumber} → isPlayoff = ${shouldBePlayoff}`)
+  }
+}
+console.log('Done.')
+await prisma.$disconnect()

--- a/tests/unit/utils.test.js
+++ b/tests/unit/utils.test.js
@@ -77,11 +77,34 @@ describe('getSlotInfo()', () => {
 })
 
 describe('getDivisionInfo()', () => {
-  it('returns Diamond for rank 1 in COED', () => {
+  it('returns Diamond for ranks 1-6 in COED (24 teams)', () => {
     expect(getDivisionInfo(1, 24, 'coed').name).toBe('Diamond')
+    expect(getDivisionInfo(6, 24, 'coed').name).toBe('Diamond')
   })
-  it('returns Bronze for last in COED', () => {
-    expect(getDivisionInfo(24, 24, 'coed').name).toBe('Bronze')
+  it('returns Platinum for ranks 7-12 in COED', () => {
+    expect(getDivisionInfo(7, 24, 'coed').name).toBe('Platinum')
+    expect(getDivisionInfo(12, 24, 'coed').name).toBe('Platinum')
+  })
+  it('returns Gold for ranks 13-18 in COED', () => {
+    expect(getDivisionInfo(13, 24, 'coed').name).toBe('Gold')
+    expect(getDivisionInfo(18, 24, 'coed').name).toBe('Gold')
+  })
+  it('returns Silver for ranks 19-24 in COED (no more Bronze)', () => {
+    expect(getDivisionInfo(19, 24, 'coed').name).toBe('Silver')
+    expect(getDivisionInfo(24, 24, 'coed').name).toBe('Silver')
+  })
+  it('never surfaces Bronze on COED', () => {
+    const names = Array.from({ length: 24 }, (_, i) => getDivisionInfo(i + 1, 24, 'coed').name)
+    expect(names.every(n => n !== 'Bronze')).toBe(true)
+  })
+  it('handles non-24-team COED seasons with extras stacked into top divisions', () => {
+    // 22 teams → 6/6/5/5 (Diamond + Platinum get the extras)
+    expect(getDivisionInfo(6, 22, 'coed').name).toBe('Diamond')
+    expect(getDivisionInfo(7, 22, 'coed').name).toBe('Platinum')
+    expect(getDivisionInfo(12, 22, 'coed').name).toBe('Platinum')
+    expect(getDivisionInfo(13, 22, 'coed').name).toBe('Gold')
+    expect(getDivisionInfo(17, 22, 'coed').name).toBe('Gold')
+    expect(getDivisionInfo(18, 22, 'coed').name).toBe('Silver')
   })
   it('splits MENS evenly into Diamond and Platinum (12 teams)', () => {
     expect(getDivisionInfo(1, 12, 'mens').name).toBe('Diamond')


### PR DESCRIPTION
The captain's package for Tuesday COED Season 9 collapsed the legacy 5-way payout (Diamond/Platinum/Gold/Silver/Bronze, 5-5-5-5-4) into a clean 4-way split — Diamond/Platinum/Gold/Silver, 6 teams each — so every division has the team count needed for the new playoff bracket (top-2 byes + 3v6 + 4v5 -> reseeded SF + Final).

- getDivisionInfo: COED now partitions teams into 4 contiguous buckets with extras stacked into the higher-prestige divisions (24 -> 6/6/6/6, 22 -> 6/6/5/5, etc.). Bronze removed from the divisions array; existing callers reach the same render path because the Silver bucket absorbs the bottom 6.
- Unit tests: replaced the old "Bronze for last in COED" expectation with full coverage of the new 4-way split + leftover stacking. 32 tests pass.
- Copy refresh on /standings, /leagues, /rules, the FAQ JSON-LD, and the home-page "PLAYOFFS" step - all now describe 4 divisions and the new W10/W11 playoff structure.
- Tuesday COED season config: playoffWeeks bumped from 1 -> 2 so W10 (QFs) + W11 (SF/F) are both flagged as playoff weeks. Seed defaults updated to match. scripts/update-coed-season-config.mjs patches the live database (idempotent).

Playoff bracket generator (W10 = 3v6 + 4v5 per division; W11 = 1 v lowest-seed-W10-winner + 2 v highest-seed-W10-winner, then Final 11 PM) is a follow-up PR.