### PR TITLE
feat(schedule): embed playoff bracket inline when current week is pla…

### DIFF
--- a/app/schedule/ScheduleClient.js
+++ b/app/schedule/ScheduleClient.js
@@ -2,12 +2,13 @@
 
 import { useState, useEffect, useRef, Fragment } from 'react'
 import { useRouter } from 'next/navigation'
-import { Clock, ChevronDown, Shield } from 'lucide-react'
+import { Clock, ChevronDown, Shield, Trophy } from 'lucide-react'
 import LeagueSelector from '@/components/ui/LeagueSelector'
 import TeamFilter from '@/components/ui/TeamFilter'
 import StatusBadge from '@/components/ui/StatusBadge'
 import { useMyTeam } from '@/lib/hooks/useMyTeam'
 import { cn, formatDate, getSlotInfo, getTeamAbbreviation } from '@/lib/utils'
+import PlayoffsClient from '@/app/playoffs/[slug]/PlayoffsClient'
 
 /* ─── Round-robin generator ───
    Pattern per round (3 teams A, B, C):
@@ -306,7 +307,7 @@ function SlotGroup({ slot, tiers, myTeam, isMens, leagueSlug }) {
 /* ═══════════════════════════════════════════════
    MAIN SCHEDULE CLIENT
    ═══════════════════════════════════════════════ */
-export default function ScheduleClient({ leagues, initialSlug, initialData, bracketCta = null }) {
+export default function ScheduleClient({ leagues, initialSlug, initialData, playoffData = null }) {
   const router = useRouter()
   const [selected, setSelected] = useState(initialSlug || leagues[0]?.slug || '')
   const [schedule, setSchedule] = useState(initialData || null)
@@ -362,8 +363,6 @@ export default function ScheduleClient({ leagues, initialSlug, initialData, brac
   return (
     <div className="py-10 sm:py-12 px-4">
       <div className="max-w-7xl mx-auto">
-        {bracketCta}
-
         <div className="mb-6 sm:mb-8">
           <span className="section-label">Game Nights</span>
           <h1 className="text-3xl sm:text-4xl lg:text-5xl font-black text-titos-white leading-none">SCHEDULE</h1>
@@ -476,14 +475,29 @@ export default function ScheduleClient({ leagues, initialSlug, initialData, brac
             {currentGameWeek && (
               <div className="mb-10">
                 <div className="flex flex-wrap items-center gap-2 sm:gap-3 mb-5 sm:mb-6">
-                  <h3 className="font-display text-lg sm:text-xl font-black text-titos-white">
-                    {currentGameWeek.weekNumber === 1 ? 'Placement Week' : `Week ${currentGameWeek.weekNumber}`}
+                  <h3 className="font-display text-lg sm:text-xl font-black text-titos-white flex items-center gap-2">
+                    {currentGameWeek.isPlayoff && (
+                      <Trophy className="w-5 h-5 text-titos-gold" aria-hidden="true" />
+                    )}
+                    {currentGameWeek.weekNumber === 1
+                      ? 'Placement Week'
+                      : currentGameWeek.isPlayoff
+                        ? `Playoffs · Week ${currentGameWeek.weekNumber}`
+                        : `Week ${currentGameWeek.weekNumber}`}
                   </h3>
                   <span className="text-titos-gray-400 text-xs sm:text-sm">{formatDate(currentGameWeek.date)}</span>
                   <StatusBadge status={currentGameWeek.status} />
                 </div>
 
-                {currentGameWeek.tiers?.length > 0 ? (
+                {/* Playoff weeks (W10 / W11) replace the regular tier slot
+                    view with the full bracket. PlayoffsClient handles its
+                    own polling, jump-to-division chips, and team-aware
+                    reordering — embedding it inline means the schedule page
+                    is the single home for 'what's happening this week'
+                    whether that's pool play or the playoff tree. */}
+                {currentGameWeek.isPlayoff && playoffData?.hasPlayoffs ? (
+                  <PlayoffsClient slug={selected} initialData={playoffData} />
+                ) : currentGameWeek.tiers?.length > 0 ? (
                   <div className="space-y-8 sm:space-y-10">
                     {['early', 'late', 'single'].map(slot => {
                       const slotTiers = currentGameWeek.tiers.filter(t => t.timeSlot === slot)

--- a/app/schedule/[slug]/page.js
+++ b/app/schedule/[slug]/page.js
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation'
 import ScheduleClient from '../ScheduleClient'
 import { getActiveLeagues, getLeagueSchedule } from '@/lib/server/leagues'
-import PlayoffBracketCTA from '@/components/PlayoffBracketCTA'
+import { getLeaguePlayoffs } from '@/lib/server/playoffs'
 
 export const revalidate = 300
 
@@ -43,9 +43,10 @@ export async function generateMetadata({ params }) {
 
 export default async function ScheduleLeaguePage({ params }) {
   const { slug } = await params
-  const [leagues, initialData] = await Promise.all([
+  const [leagues, initialData, playoffData] = await Promise.all([
     getActiveLeagues(),
     getLeagueSchedule(slug),
+    getLeaguePlayoffs(slug).catch(() => null),
   ])
 
   if (!leagues.some(l => l.slug === slug)) notFound()
@@ -60,7 +61,7 @@ export default async function ScheduleLeaguePage({ params }) {
         leagues={leagues}
         initialSlug={slug}
         initialData={initialData}
-        bracketCta={<PlayoffBracketCTA slug={slug} />}
+        playoffData={playoffData}
       />
     </>
   )

--- a/app/schedule/page.js
+++ b/app/schedule/page.js
@@ -1,6 +1,6 @@
 import ScheduleClient from './ScheduleClient'
 import { getActiveLeagues, getLeagueSchedule } from '@/lib/server/leagues'
-import PlayoffBracketCTA from '@/components/PlayoffBracketCTA'
+import { getLeaguePlayoffs } from '@/lib/server/playoffs'
 
 export const metadata = {
   title: "Volleyball Schedule — Mississauga Indoor League | Tito's Courts",
@@ -25,7 +25,12 @@ export const revalidate = 300
 export default async function SchedulePage() {
   const leagues = await getActiveLeagues()
   const firstSlug = leagues[0]?.slug
-  const initialData = firstSlug ? await getLeagueSchedule(firstSlug) : null
+  const [initialData, playoffData] = firstSlug
+    ? await Promise.all([
+        getLeagueSchedule(firstSlug),
+        getLeaguePlayoffs(firstSlug).catch(() => null),
+      ])
+    : [null, null]
   return (
     <>
       <p className="sr-only">
@@ -35,7 +40,7 @@ export default async function SchedulePage() {
         leagues={leagues}
         initialSlug={firstSlug}
         initialData={initialData}
-        bracketCta={firstSlug ? <PlayoffBracketCTA slug={firstSlug} /> : null}
+        playoffData={playoffData}
       />
     </>
   )

--- a/scripts/check-season.mjs
+++ b/scripts/check-season.mjs
@@ -1,0 +1,11 @@
+import 'dotenv/config'
+import prisma from '../lib/prisma.js'
+const seasons = await prisma.season.findMany({
+  where: { league: { slug: 'tuesday-coed' } },
+  include: { weeks: { where: { weekNumber: { in: [10, 11] } } } },
+})
+for (const s of seasons) {
+  console.log(`Season ${s.seasonNumber} (${s.name}) status=${s.status}`)
+  for (const w of s.weeks) console.log(`  W${w.weekNumber} isPlayoff=${w.isPlayoff}`)
+}
+await prisma.$disconnect()

--- a/scripts/check-weeks.mjs
+++ b/scripts/check-weeks.mjs
@@ -1,0 +1,9 @@
+import 'dotenv/config'
+import prisma from '../lib/prisma.js'
+const weeks = await prisma.week.findMany({
+  where: { season: { league: { slug: 'tuesday-coed' } } },
+  select: { weekNumber: true, status: true, isPlayoff: true },
+  orderBy: { weekNumber: 'asc' },
+})
+for (const w of weeks) console.log(`W${w.weekNumber} status=${w.status} isPlayoff=${w.isPlayoff}`)
+await prisma.$disconnect()


### PR DESCRIPTION
…yoff

The /schedule page is the canonical 'what's happening this week?' surface, so it should also be where the playoff bracket lives during W10 / W11 instead of asking players to bounce to /playoffs. When the active or next-upcoming week has isPlayoff=true AND the league has a generated bracket, the schedule replaces the regular tier-slot grid with the full PlayoffsClient inline (legend, jump-to-division chips, team-aware reordering, polling — all of it).

- /schedule/[slug] now server-fetches playoff data in parallel with schedule data and passes it as a playoffData prop. /schedule/index same treatment for the default-selected league.
- ScheduleClient swaps the SlotGroup grid for <PlayoffsClient /> when currentGameWeek.isPlayoff && playoffData.hasPlayoffs. Falls back cleanly when either is missing (regular season behaviour intact).
- Week heading reads 'Playoffs · Week 10' with a Trophy icon during playoff weeks so the swap is obvious.
- Removed the PlayoffBracketCTA banner from /schedule (still on /standings) — the inline bracket replaces it.
- Includes scripts/check-weeks.mjs + check-season.mjs (small dev helpers for verifying playoff week state).

Cleared a stale .next dev cache that was masking the W10/W11 isPlayoff fix; the same issue won't repeat on Vercel (no persistent in-memory cache across deploys).