### PR TITLE
fix(standings): exclude playoff weeks from regular-season standings

### DIFF
--- a/app/api/admin/seasons/[id]/playoffs/route.js
+++ b/app/api/admin/seasons/[id]/playoffs/route.js
@@ -255,8 +255,12 @@ async function computeEndOfSeasonStandings(seasonId) {
       tiers: { orderBy: { tierNumber: 'asc' } },
       weeks: {
         where: {
+          // Defense in depth: weekNumber filter is the authoritative bound,
+          // but isPlayoff:false guards against any future week-renumbering
+          // that might let a playoff week slip into the standings input.
           weekNumber: { lte: REGULAR_SEASON_WEEKS },
           status: 'completed',
+          isPlayoff: false,
         },
         include: {
           matches: {

--- a/lib/server/leagues.js
+++ b/lib/server/leagues.js
@@ -145,7 +145,13 @@ export function getLeagueStandings(slug) {
             include: {
               teams: true,
               weeks: {
-                where: { status: 'completed' },
+                // Standings are LOCKED at the end of the regular season —
+                // playoff matches (W10 QFs / W11 SFs+F) must NOT count toward
+                // setsWon / pointDiff / basePoints. Otherwise a team that
+                // wins their QF would jump in the rank table and the
+                // standings displayed to captains during playoffs would
+                // misrepresent the regular-season finish.
+                where: { status: 'completed', isPlayoff: false },
                 include: {
                   matches: {
                     where: { status: 'completed' },


### PR DESCRIPTION
Critical: getLeagueStandings was iterating every status:completed week INCLUDING W10 / W11 once those flipped to completed. That meant:

- Standings on /standings shifted as playoff QFs went FINAL. A team could leapfrog ahead in setsWon by winning a single QF, even though end-of-season standings are supposed to be locked.
- Captains looking at the standings page during playoffs saw the WRONG regular-season finish, which made the 3v6 / 4v5 QF matchups look incorrect ('why is Tacos at #4 when they should be #6?') and by extension the SF reseed looked wrong too.

Fix: the inner weeks query now filters `isPlayoff: false` so only W1-W9 contribute to the standings ledger. The bracket-generation route's computeEndOfSeasonStandings was already weekNumber-bounded to ≤9, so seeds were always correct AT GENERATION TIME — but I added a defensive `isPlayoff: false` there too in case anyone removes the weekNumber filter later.

advancePlayoffWinner.js reads QF seeds from the static homeSeedLabel / awaySeedLabel set at bracket generation, so the SF reseed is unaffected by the live standings recompute. Tests confirm the reseed still uses end-of-W9 ranks. The only visible change is the /standings page now stays locked once playoffs begin, matching what captains expect.