### PR TITLE
Hotfix/playoff standings

### DIFF
--- a/lib/league/advancePlayoffWinner.js
+++ b/lib/league/advancePlayoffWinner.js
@@ -74,12 +74,27 @@ export async function advancePlayoffWinner(matchId, prisma = prismaClient) {
   }
 
   // QF → SF reseeding. The two QFs in this division feed SF1 (faces seed 1)
-  // and SF2 (faces seed 2). The wiring in the generator points each QF at
-  // ONE SF by gameOrder; we override based on reseeding once BOTH QFs have
-  // winners. If only one QF is done so far, drop the winner into the wired
-  // SF — when the second QF lands, this function rebalances both slots.
+  // and SF2 (faces seed 2). We DON'T trust the wired nextMatchId for the
+  // away-slot placement — instead, whenever a QF finalizes we recompute
+  // BOTH SF away slots from scratch:
+  //   - better-seeded QF winner (smaller seed #)  → SF2 away (faces seed 2)
+  //   - worse-seeded QF winner  (bigger seed #)   → SF1 away (faces seed 1)
+  // The #1 seed must always draw the WEAKEST advancing team.
+  // If only one QF is done so far, we leave the SF away slots EMPTY rather
+  // than doing a partial placement that needs later correction — the second
+  // QF's finalization fills both slots atomically. This removes the fragile
+  // rebalance path that previously let a wrong placement persist when the
+  // sibling-lookup query missed.
   if (next.roundNumber === PLAYOFF_ROUND.SF) {
-    // Get the two QFs in this division
+    // Resolve the season so we can find the division's SFs without relying
+    // on a brittle nested relation filter.
+    const qfWeek = await prisma.week.findUnique({
+      where: { id: match.weekId },
+      select: { seasonId: true },
+    })
+    const seasonId = qfWeek?.seasonId
+
+    // Both QFs in this division (same QF week + tier).
     const allQfs = await prisma.match.findMany({
       where: {
         weekId: match.weekId,
@@ -87,49 +102,37 @@ export async function advancePlayoffWinner(matchId, prisma = prismaClient) {
         roundNumber: PLAYOFF_ROUND.QF,
       },
       select: {
-        id: true,
-        status: true,
-        winnerId: true,
-        homeSeedLabel: true,
-        awaySeedLabel: true,
-        homeTeamId: true,
-        awayTeamId: true,
-        gameOrder: true,
+        id: true, status: true, winnerId: true,
+        homeSeedLabel: true, awaySeedLabel: true,
+        homeTeamId: true, awayTeamId: true, gameOrder: true,
       },
       orderBy: { gameOrder: 'asc' },
     })
-
     const other = allQfs.find(q => q.id !== match.id)
 
-    // If the other QF isn't done yet, just write into the wired SF.
-    if (!other || other.status !== 'completed' || !other.winnerId) {
-      const slot = next.homeTeamId ? 'away' : 'home'
-      await writeSlot(prisma, next.id, slot, match.winnerId)
-      return { advanced: true, nextMatchId: next.id, slot, pendingSibling: true }
-    }
-
-    // Both QFs are final — apply reseed rule. The two SFs are in the same
-    // season's next week (W11) and the same division (tierNumber).
+    // Both SFs in this division (any week in the season, SF round, same tier).
     const sfs = await prisma.match.findMany({
       where: {
         tierNumber: match.tierNumber,
         roundNumber: PLAYOFF_ROUND.SF,
-        week: { season: { weeks: { some: { id: match.weekId } } } },
+        ...(seasonId ? { week: { seasonId } } : {}),
       },
       orderBy: { gameOrder: 'asc' },
       select: { id: true, gameOrder: true },
     })
-    if (sfs.length !== 2) {
-      // Defensive: fall back to wired placement
-      const slot = next.homeTeamId ? 'away' : 'home'
-      await writeSlot(prisma, next.id, slot, match.winnerId)
-      return { advanced: true, fallback: true }
-    }
-    const [sf1, sf2] = sfs
 
+    // If the sibling QF isn't decided yet, hold both away slots empty.
+    if (!other || other.status !== 'completed' || !other.winnerId) {
+      return { advanced: false, reason: 'awaiting sibling QF', pendingSibling: true }
+    }
+    if (sfs.length !== 2) {
+      return { advanced: false, reason: `expected 2 SFs, found ${sfs.length}` }
+    }
+
+    const [sf1, sf2] = sfs
     const mySeed = winnerSeedOf(match)
     const otherSeed = winnerSeedOf(other)
-    // Better seed (smaller number) faces the 2 seed (SF2 away slot).
+    // Better seed (smaller number) → SF2 (faces the 2 seed).
     const betterWinnerId = mySeed < otherSeed ? match.winnerId : other.winnerId
     const worseWinnerId  = mySeed < otherSeed ? other.winnerId : match.winnerId
 

--- a/scripts/check-coed-bracket-state.mjs
+++ b/scripts/check-coed-bracket-state.mjs
@@ -1,0 +1,33 @@
+import 'dotenv/config'
+import prisma from '../lib/prisma.js'
+
+const league = await prisma.league.findUnique({
+  where: { slug: 'tuesday-coed' },
+  include: { seasons: { where: { status: { in: ['active', 'playoffs'] } }, orderBy: { seasonNumber: 'desc' }, take: 1 } },
+})
+const seasonId = league.seasons[0].id
+const w10 = await prisma.week.findFirst({ where: { seasonId, weekNumber: 10 } })
+const w11 = await prisma.week.findFirst({ where: { seasonId, weekNumber: 11 } })
+
+const DIV = { 1: 'Diamond', 2: 'Platinum', 3: 'Gold', 4: 'Silver' }
+
+for (const tier of [1, 2, 3, 4]) {
+  console.log(`\n=== ${DIV[tier]} (tier ${tier}) ===`)
+  const qfs = await prisma.match.findMany({
+    where: { weekId: w10.id, tierNumber: tier, roundNumber: 1 },
+    include: { homeTeam: { select: { name: true } }, awayTeam: { select: { name: true } }, winnerTeam: { select: { name: true } } },
+    orderBy: { gameOrder: 'asc' },
+  })
+  for (const q of qfs) {
+    console.log(`  QF${q.gameOrder}: ${q.homeSeedLabel}(${q.homeTeam?.name}) vs ${q.awaySeedLabel}(${q.awayTeam?.name}) | ${q.status} | winner=${q.winnerTeam?.name || '—'}`)
+  }
+  const sfs = await prisma.match.findMany({
+    where: { weekId: w11.id, tierNumber: tier, roundNumber: 2 },
+    include: { homeTeam: { select: { name: true } }, awayTeam: { select: { name: true } } },
+    orderBy: { gameOrder: 'asc' },
+  })
+  for (const s of sfs) {
+    console.log(`  SF${s.gameOrder}: ${s.homeSeedLabel}(${s.homeTeam?.name || '—'}) vs ${s.awaySeedLabel}(${s.awayTeam?.name || 'EMPTY'})`)
+  }
+}
+await prisma.$disconnect()

--- a/scripts/check-coed-playoff-seeds.mjs
+++ b/scripts/check-coed-playoff-seeds.mjs
@@ -1,0 +1,88 @@
+// Recompute Tuesday COED end-of-W9 standings (playoff weeks excluded, same
+// logic as the admin playoff-seeding) and print what the Diamond division
+// bracket SHOULD look like, vs what's currently persisted.
+
+import 'dotenv/config'
+import prisma from '../lib/prisma.js'
+
+const REGULAR = 9
+
+const league = await prisma.league.findUnique({
+  where: { slug: 'tuesday-coed' },
+  include: { seasons: { where: { status: { in: ['active', 'playoffs'] } }, orderBy: { seasonNumber: 'desc' }, take: 1 } },
+})
+const seasonId = league.seasons[0].id
+
+const season = await prisma.season.findUnique({
+  where: { id: seasonId },
+  include: {
+    teams: true,
+    weeks: {
+      where: { weekNumber: { lte: REGULAR }, status: 'completed', isPlayoff: false },
+      include: { matches: { where: { status: 'completed' }, include: { scores: true } } },
+    },
+  },
+})
+
+const teamStats = {}
+for (const t of season.teams) teamStats[t.id] = { id: t.id, name: t.name, setsWon: 0, pointDiff: 0, totalPoints: 0 }
+
+for (const week of season.weeks) {
+  if (week.weekNumber === 1) continue
+  const wts = {}
+  for (const m of week.matches) {
+    for (const s of m.scores) {
+      const homeWon = s.homeScore > s.awayScore
+      const diff = s.homeScore - s.awayScore
+      wts[m.homeTeamId] = wts[m.homeTeamId] || { sets: 0, tierNumber: m.tierNumber }
+      wts[m.awayTeamId] = wts[m.awayTeamId] || { sets: 0, tierNumber: m.tierNumber }
+      if (homeWon) {
+        wts[m.homeTeamId].sets++
+        if (teamStats[m.homeTeamId]) { teamStats[m.homeTeamId].setsWon++; teamStats[m.homeTeamId].pointDiff += diff }
+        if (teamStats[m.awayTeamId]) teamStats[m.awayTeamId].pointDiff -= diff
+      } else {
+        wts[m.awayTeamId].sets++
+        if (teamStats[m.awayTeamId]) { teamStats[m.awayTeamId].setsWon++; teamStats[m.awayTeamId].pointDiff += Math.abs(diff) }
+        if (teamStats[m.homeTeamId]) teamStats[m.homeTeamId].pointDiff -= Math.abs(diff)
+      }
+    }
+  }
+  const maxTier = Math.max(...Object.values(wts).map(d => d.tierNumber || 1), 1)
+  for (const [tid, d] of Object.entries(wts)) {
+    if (!teamStats[tid]) continue
+    const tf = (maxTier - (d.tierNumber || 1)) + 1
+    teamStats[tid].totalPoints += tf + d.sets
+  }
+}
+
+const ranked = Object.values(teamStats)
+  .sort((a, b) => (b.totalPoints - a.totalPoints) || (b.pointDiff - a.pointDiff))
+  .map((t, i) => ({ ...t, rank: i + 1 }))
+
+console.log('CORRECTED end-of-W9 standings (top 6 = Diamond):')
+for (const t of ranked.slice(0, 6)) {
+  console.log(`  #${t.rank} ${t.name.padEnd(22)} pts=${t.totalPoints} SW=${t.setsWon} +/-${t.pointDiff}`)
+}
+
+const d = ranked.slice(0, 6)
+console.log('\nDiamond bracket SHOULD be:')
+console.log(`  QF1: ${d[2].name} (3) vs ${d[5].name} (6)`)
+console.log(`  QF2: ${d[3].name} (4) vs ${d[4].name} (5)`)
+console.log(`  SF1: ${d[0].name} (1) vs Lower-seed QF winner`)
+console.log(`  SF2: ${d[1].name} (2) vs Higher-seed QF winner`)
+
+// Current persisted Diamond bracket (tierNumber 1)
+const w10 = await prisma.week.findFirst({ where: { seasonId, weekNumber: 10 } })
+const w11 = await prisma.week.findFirst({ where: { seasonId, weekNumber: 11 } })
+const bracket = await prisma.match.findMany({
+  where: { weekId: { in: [w10?.id, w11?.id].filter(Boolean) }, tierNumber: 1 },
+  include: { homeTeam: { select: { name: true } }, awayTeam: { select: { name: true } } },
+  orderBy: [{ roundNumber: 'asc' }, { gameOrder: 'asc' }],
+})
+console.log('\nCurrently PERSISTED Diamond bracket:')
+for (const m of bracket) {
+  const r = { 1: 'QF', 2: 'SF', 3: 'F' }[m.roundNumber]
+  console.log(`  ${r}${m.gameOrder}: ${m.homeTeam?.name || m.homeSeedLabel} vs ${m.awayTeam?.name || m.awaySeedLabel}`)
+}
+
+await prisma.$disconnect()

--- a/scripts/check-mens-w9.mjs
+++ b/scripts/check-mens-w9.mjs
@@ -1,0 +1,32 @@
+import 'dotenv/config'
+import prisma from '../lib/prisma.js'
+
+const league = await prisma.league.findUnique({
+  where: { slug: 'sunday-mens' },
+  include: { seasons: { where: { status: { in: ['active', 'playoffs'] } }, orderBy: { seasonNumber: 'desc' }, take: 1 } },
+})
+const season = league.seasons[0]
+const w9 = await prisma.week.findFirst({ where: { seasonId: season.id, weekNumber: 9 } })
+if (!w9) { console.log('No W9'); process.exit(0) }
+console.log(`W9 id=${w9.id} status=${w9.status}`)
+
+const placements = await prisma.tierPlacement.findMany({
+  where: { weekId: w9.id },
+  include: { team: { select: { name: true } }, tier: { select: { tierNumber: true } } },
+  // No orderBy — mirror the schedule query so we see the real insertion order.
+})
+const byTier = {}
+for (const p of placements) {
+  const tn = p.tier.tierNumber
+  byTier[tn] = byTier[tn] || []
+  byTier[tn].push(p)
+}
+console.log('\nPlacements (DB insertion order):')
+for (const tn of Object.keys(byTier).sort((a,b)=>a-b)) {
+  console.log(`Tier ${tn}:`)
+  byTier[tn].forEach((p, i) => console.log(`  [${i}] ${p.team.name} (finishPos=${p.finishPosition ?? 'null'})`))
+}
+
+const matchCount = await prisma.match.count({ where: { weekId: w9.id } })
+console.log(`\nW9 matches: ${matchCount}`)
+await prisma.$disconnect()

--- a/scripts/fix-coed-sf-reseed.mjs
+++ b/scripts/fix-coed-sf-reseed.mjs
@@ -1,0 +1,63 @@
+// Re-apply the correct QF→SF reseed for every Tuesday COED playoff division.
+//
+// Rule (per division): of the two QF winners, the BETTER seed (smaller #)
+// faces the 2 seed (SF2); the WORSE seed faces the 1 seed (SF1). The #1
+// overall seed must get the weakest team that advanced.
+//
+// The live bracket had this inverted in all 4 divisions (SF1 got the
+// better winner, SF2 got the worse) because the runtime reseed fell
+// through to naive QF1→SF1 / QF2→SF2 wiring. This recomputes both SF
+// away slots from scratch. Idempotent.
+
+import 'dotenv/config'
+import prisma from '../lib/prisma.js'
+
+const seedFromLabel = (label) => {
+  const m = (label || '').match(/(\d+)\s*$/)
+  return m ? Number(m[1]) : Infinity
+}
+
+const league = await prisma.league.findUnique({
+  where: { slug: 'tuesday-coed' },
+  include: { seasons: { where: { status: { in: ['active', 'playoffs'] } }, orderBy: { seasonNumber: 'desc' }, take: 1 } },
+})
+const seasonId = league.seasons[0].id
+const w10 = await prisma.week.findFirst({ where: { seasonId, weekNumber: 10 } })
+const w11 = await prisma.week.findFirst({ where: { seasonId, weekNumber: 11 } })
+
+const DIV = { 1: 'Diamond', 2: 'Platinum', 3: 'Gold', 4: 'Silver' }
+
+for (const tier of [1, 2, 3, 4]) {
+  const qfs = await prisma.match.findMany({
+    where: { weekId: w10.id, tierNumber: tier, roundNumber: 1 },
+    orderBy: { gameOrder: 'asc' },
+  })
+  if (qfs.length !== 2 || qfs.some(q => q.status !== 'completed' || !q.winnerId)) {
+    console.log(`${DIV[tier]}: QFs not both final — skipping`)
+    continue
+  }
+  // Seed of each winner.
+  const winnerSeed = (q) => seedFromLabel(q.winnerId === q.homeTeamId ? q.homeSeedLabel : q.awaySeedLabel)
+  const [a, b] = qfs
+  const aSeed = winnerSeed(a)
+  const bSeed = winnerSeed(b)
+  const betterWinnerId = aSeed < bSeed ? a.winnerId : b.winnerId
+  const worseWinnerId  = aSeed < bSeed ? b.winnerId : a.winnerId
+
+  const sfs = await prisma.match.findMany({
+    where: { weekId: w11.id, tierNumber: tier, roundNumber: 2 },
+    orderBy: { gameOrder: 'asc' },
+  })
+  if (sfs.length !== 2) { console.log(`${DIV[tier]}: expected 2 SFs, found ${sfs.length} — skipping`); continue }
+  const [sf1, sf2] = sfs
+
+  // SF1 (faces seed 1) gets the WORSE winner; SF2 (faces seed 2) gets the BETTER winner.
+  await prisma.match.update({ where: { id: sf1.id }, data: { awayTeamId: worseWinnerId } })
+  await prisma.match.update({ where: { id: sf2.id }, data: { awayTeamId: betterWinnerId } })
+
+  const nameOf = async (id) => (await prisma.team.findUnique({ where: { id }, select: { name: true } }))?.name
+  console.log(`${DIV[tier]}: SF1 away → ${await nameOf(worseWinnerId)} (worse), SF2 away → ${await nameOf(betterWinnerId)} (better)`)
+}
+
+console.log('\nDone. Hard-refresh /schedule/tuesday-coed or /playoffs/tuesday-coed.')
+await prisma.$disconnect()

--- a/scripts/fix-mens-w9-order.mjs
+++ b/scripts/fix-mens-w9-order.mjs
@@ -1,0 +1,102 @@
+// Fix the Sunday MENS Week 9 within-tier ordering. The tier MEMBERSHIP is
+// already correct, but the placements were inserted in the wrong order
+// (display + match generation both rely on DB insertion order), so the
+// seed-1/2/3 within each tier — and the round-robin home/away/ref rotation
+// derived from it — were wrong.
+//
+// This recreates the W9 placements in the captain-confirmed order and
+// regenerates the 36 matches using the same round-robin pattern the admin
+// 'generate-matches' endpoint uses (A vs C, B vs A, C vs B × 3 MENS rounds).
+//
+// Safe: W9 is UPCOMING with no scores, so nothing is lost.
+
+import 'dotenv/config'
+import prisma from '../lib/prisma.js'
+
+// Captain-confirmed Week 9 order (seed 1 → 3 within each tier).
+const DESIRED = {
+  1: ['Tsunami Riptide', 'AkatsuKILL', 'Out of Your League'],
+  2: ['Boys 2 Men', 'Schweiden', 'Sets on the Beach'],
+  3: ['Block Party', 'United Nations', 'Glizzy Gobblers'],
+  4: ['Friends', 'Spike Syndicate', "Ricky's Babics"],
+}
+
+const league = await prisma.league.findUnique({
+  where: { slug: 'sunday-mens' },
+  include: {
+    seasons: {
+      where: { status: { in: ['active', 'playoffs'] } },
+      orderBy: { seasonNumber: 'desc' },
+      take: 1,
+      include: { tiers: true, teams: { select: { id: true, name: true } } },
+    },
+  },
+})
+const season = league.seasons[0]
+const w9 = await prisma.week.findFirst({ where: { seasonId: season.id, weekNumber: 9 } })
+if (!w9) { console.error('No W9'); process.exit(1) }
+
+const teamByName = Object.fromEntries(season.teams.map(t => [t.name, t.id]))
+const tierByNumber = Object.fromEntries(season.tiers.map(t => [t.tierNumber, t]))
+
+// Validate every desired team resolves before we touch anything.
+for (const [tn, names] of Object.entries(DESIRED)) {
+  for (const name of names) {
+    if (!teamByName[name]) { console.error(`Team not found: "${name}" (tier ${tn})`); process.exit(1) }
+  }
+  if (!tierByNumber[tn]) { console.error(`Tier ${tn} not found`); process.exit(1) }
+}
+
+// 1. Wipe W9 matches (+ any scores — none for upcoming) and placements.
+const oldMatches = await prisma.match.findMany({ where: { weekId: w9.id }, select: { id: true } })
+const oldIds = oldMatches.map(m => m.id)
+if (oldIds.length) {
+  await prisma.setScore.deleteMany({ where: { matchId: { in: oldIds } } })
+  await prisma.playerStat.deleteMany({ where: { matchId: { in: oldIds } } })
+  await prisma.match.deleteMany({ where: { weekId: w9.id } })
+}
+await prisma.tierPlacement.deleteMany({ where: { weekId: w9.id } })
+console.log(`Cleared ${oldIds.length} matches + old placements`)
+
+// 2. Recreate placements in the desired order (insertion order = display order).
+let placed = 0
+for (const [tn, names] of Object.entries(DESIRED)) {
+  const tier = tierByNumber[tn]
+  for (const name of names) {
+    await prisma.tierPlacement.create({
+      data: { tierId: tier.id, teamId: teamByName[name], weekId: w9.id, finishPosition: null, movement: null },
+    })
+    placed++
+  }
+}
+console.log(`Created ${placed} placements in correct order`)
+
+// 3. Regenerate matches — MENS = 3 rounds, round-robin A vs C / B vs A / C vs B.
+const ROUNDS = 3
+let matchCount = 0
+for (const [tn, names] of Object.entries(DESIRED)) {
+  const tier = tierByNumber[tn]
+  const [A, B, C] = names.map(n => teamByName[n])
+  for (let r = 1; r <= ROUNDS; r++) {
+    const base = (r - 1) * 3
+    const defs = [
+      { home: A, away: C, ref: B, order: base + 1 },
+      { home: B, away: A, ref: C, order: base + 2 },
+      { home: C, away: B, ref: A, order: base + 3 },
+    ]
+    for (const d of defs) {
+      await prisma.match.create({
+        data: {
+          weekId: w9.id,
+          homeTeamId: d.home, awayTeamId: d.away, refTeamId: d.ref,
+          courtNumber: tier.courtNumber, tierNumber: tier.tierNumber,
+          roundNumber: r, gameOrder: d.order, status: 'scheduled',
+        },
+      })
+      matchCount++
+    }
+  }
+}
+console.log(`Regenerated ${matchCount} matches`)
+console.log('\nDone. Hard-refresh /schedule/sunday-mens to see W9 in the correct order.')
+await prisma.$disconnect()

--- a/tests/unit/league/advancePlayoffWinner.test.js
+++ b/tests/unit/league/advancePlayoffWinner.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest'
+import { advancePlayoffWinner } from '@/lib/league/advancePlayoffWinner'
+
+// Builds a minimal in-memory Prisma double for the playoff advance logic.
+// Only the calls advancePlayoffWinner actually makes are implemented.
+function makePrisma({ matches, weeks }) {
+  const byId = Object.fromEntries(matches.map(m => [m.id, m]))
+  return {
+    match: {
+      findUnique: async ({ where: { id }, select }) => byId[id] || null,
+      findMany: async ({ where }) => {
+        return matches.filter(m => {
+          if (where.weekId && m.weekId !== where.weekId) return false
+          if (where.tierNumber != null && m.tierNumber !== where.tierNumber) return false
+          if (where.roundNumber != null && m.roundNumber !== where.roundNumber) return false
+          if (where.week?.seasonId && weeks[m.weekId]?.seasonId !== where.week.seasonId) return false
+          return true
+        }).sort((a, b) => (a.gameOrder ?? 0) - (b.gameOrder ?? 0))
+      },
+      update: async ({ where: { id }, data }) => {
+        Object.assign(byId[id], data)
+        return byId[id]
+      },
+    },
+    week: {
+      findUnique: async ({ where: { id } }) => weeks[id] || null,
+    },
+  }
+}
+
+describe('advancePlayoffWinner — QF→SF reseed', () => {
+  // Diamond division: seeds 1..6. QF1 = 3 v 6, QF2 = 4 v 5.
+  // Winners: seed 3 (QF1) and seed 4 (QF2). The #1 seed must face the
+  // WORSE winner (seed 4); the #2 seed faces the BETTER winner (seed 3).
+  function diamondFixture() {
+    const weeks = {
+      w10: { id: 'w10', seasonId: 's1' },
+      w11: { id: 'w11', seasonId: 's1' },
+    }
+    const matches = [
+      { id: 'qf1', weekId: 'w10', tierNumber: 1, roundNumber: 1, gameOrder: 1,
+        status: 'completed', winnerId: 't3', homeTeamId: 't3', awayTeamId: 't6',
+        homeSeedLabel: 'Diamond 3', awaySeedLabel: 'Diamond 6', nextMatchId: 'sf1' },
+      { id: 'qf2', weekId: 'w10', tierNumber: 1, roundNumber: 1, gameOrder: 2,
+        status: 'completed', winnerId: 't4', homeTeamId: 't4', awayTeamId: 't5',
+        homeSeedLabel: 'Diamond 4', awaySeedLabel: 'Diamond 5', nextMatchId: 'sf2' },
+      { id: 'sf1', weekId: 'w11', tierNumber: 1, roundNumber: 2, gameOrder: 1,
+        status: 'scheduled', winnerId: null, homeTeamId: 't1', awayTeamId: null,
+        homeSeedLabel: 'Diamond 1', awaySeedLabel: 'Lower QF Winner', nextMatchId: 'final' },
+      { id: 'sf2', weekId: 'w11', tierNumber: 1, roundNumber: 2, gameOrder: 2,
+        status: 'scheduled', winnerId: null, homeTeamId: 't2', awayTeamId: null,
+        homeSeedLabel: 'Diamond 2', awaySeedLabel: 'Higher QF Winner', nextMatchId: 'final' },
+    ]
+    return { weeks, matches }
+  }
+
+  it('puts the WORSE QF winner against the 1 seed (SF1) and the BETTER against the 2 seed (SF2)', async () => {
+    const fx = diamondFixture()
+    const prisma = makePrisma(fx)
+    const res = await advancePlayoffWinner('qf2', prisma)
+    expect(res.advanced).toBe(true)
+    expect(res.reseeded).toBe(true)
+
+    const sf1 = fx.matches.find(m => m.id === 'sf1')
+    const sf2 = fx.matches.find(m => m.id === 'sf2')
+    // seed 4 (worse) faces the 1 seed; seed 3 (better) faces the 2 seed.
+    expect(sf1.awayTeamId).toBe('t4')
+    expect(sf2.awayTeamId).toBe('t3')
+  })
+
+  it('is order-independent — same result whichever QF finalizes the callback', async () => {
+    const fx = diamondFixture()
+    const prisma = makePrisma(fx)
+    // Fire on qf1 instead of qf2 — result must be identical.
+    await advancePlayoffWinner('qf1', prisma)
+    const sf1 = fx.matches.find(m => m.id === 'sf1')
+    const sf2 = fx.matches.find(m => m.id === 'sf2')
+    expect(sf1.awayTeamId).toBe('t4')
+    expect(sf2.awayTeamId).toBe('t3')
+  })
+
+  it('holds SF away slots EMPTY until the sibling QF is decided', async () => {
+    const fx = diamondFixture()
+    // QF2 not finished yet.
+    fx.matches.find(m => m.id === 'qf2').status = 'scheduled'
+    fx.matches.find(m => m.id === 'qf2').winnerId = null
+    const prisma = makePrisma(fx)
+    const res = await advancePlayoffWinner('qf1', prisma)
+    expect(res.advanced).toBe(false)
+    expect(res.pendingSibling).toBe(true)
+    expect(fx.matches.find(m => m.id === 'sf1').awayTeamId).toBe(null)
+    expect(fx.matches.find(m => m.id === 'sf2').awayTeamId).toBe(null)
+  })
+
+  it('handles a 5-seed upset winner — worse winner (5) still draws the 1 seed', async () => {
+    const fx = diamondFixture()
+    // QF2: seed 5 upsets seed 4.
+    const qf2 = fx.matches.find(m => m.id === 'qf2')
+    qf2.winnerId = 't5'
+    const prisma = makePrisma(fx)
+    await advancePlayoffWinner('qf2', prisma)
+    // Winners are seed 3 (better) and seed 5 (worse).
+    expect(fx.matches.find(m => m.id === 'sf1').awayTeamId).toBe('t5') // worse → 1 seed
+    expect(fx.matches.find(m => m.id === 'sf2').awayTeamId).toBe('t3') // better → 2 seed
+  })
+})
+
+describe('advancePlayoffWinner — SF→Final', () => {
+  it('SF1 winner is home, SF2 winner is away in the Final', async () => {
+    const weeks = { w11: { id: 'w11', seasonId: 's1' } }
+    const matches = [
+      { id: 'sf1', weekId: 'w11', tierNumber: 1, roundNumber: 2, gameOrder: 1,
+        status: 'completed', winnerId: 't1', homeTeamId: 't1', awayTeamId: 't4',
+        homeSeedLabel: 'Diamond 1', awaySeedLabel: 'Lower QF Winner', nextMatchId: 'final' },
+      { id: 'final', weekId: 'w11', tierNumber: 1, roundNumber: 3, gameOrder: 1,
+        status: 'scheduled', winnerId: null, homeTeamId: null, awayTeamId: null,
+        homeSeedLabel: 'W SF1', awaySeedLabel: 'W SF2', nextMatchId: null },
+    ]
+    const prisma = makePrisma({ weeks, matches })
+    const res = await advancePlayoffWinner('sf1', prisma)
+    expect(res.advanced).toBe(true)
+    expect(matches.find(m => m.id === 'final').homeTeamId).toBe('t1')
+  })
+})


### PR DESCRIPTION
-Standings counted playoff weeks
-Sunday MENS Week 9 within-tier order
-Semifinal reseed was inverted (all 4 COED divisions)